### PR TITLE
Fixing ByPackageHash and ByPackageName for VM2 transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,7 @@ dependencies = [
  "casper-storage",
  "casper-types",
  "regex",
+ "rkyv",
  "tracing",
  "wasmer",
  "wasmer-compiler-singlepass",
@@ -5501,13 +5502,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.11"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f5c3e5da784cd8c69d32cdc84673f3204536ca56e1fa01be31a74b92c932ac"
+checksum = "8b2e88acca7157d83d789836a3987dafc12bc3d88a050e54b8fe9ea4aaa29d20"
 dependencies = [
  "bytecheck 0.8.1",
  "bytes",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "indexmap 2.11.3",
  "munge",
  "ptr_meta 0.3.0",
@@ -5520,9 +5521,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.11"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4270433626cffc9c4c1d3707dd681f2a2718d3d7b09ad754bec137acecda8d22"
+checksum = "7f6dffea3c91fa91a3c0fc8a061b0e27fef25c6304728038a6d6bcb1c58ba9bd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7398,6 +7399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vm2-store-named-key"
+version = "0.1.0"
+dependencies = [
+ "casper-contract-sdk",
+ "casper-contract-sdk-contrib",
+ "casper-executor-wasm-common",
+]
+
+[[package]]
 name = "vm2-system-caller"
 version = "0.1.0"
 dependencies = [
@@ -7417,6 +7427,14 @@ dependencies = [
 
 [[package]]
 name = "vm2-upgradable"
+version = "0.1.0"
+dependencies = [
+ "casper-contract-macros",
+ "casper-contract-sdk",
+]
+
+[[package]]
+name = "vm2-upgradable-storing-package"
 version = "0.1.0"
 dependencies = [
  "casper-contract-macros",

--- a/binary_port/src/error_code.rs
+++ b/binary_port/src/error_code.rs
@@ -369,6 +369,7 @@ pub enum ErrorCode {
     #[error("Transaction attempts to set a delegation amount above the highest allowed value")]
     InvalidDelegationAmount = 116,
     #[error("the transaction invocation target is unsupported under V2 runtime")]
+    // This code is not used, but we had a production release with it so we can't reuse it
     UnsupportedInvocationTarget = 117,
 }
 
@@ -567,9 +568,6 @@ impl From<InvalidTransactionV1> for ErrorCode {
             InvalidTransactionV1::InvalidReservedSlots { .. } => ErrorCode::InvalidReservedSlots,
             InvalidTransactionV1::InvalidDelegationAmount { .. } => {
                 ErrorCode::InvalidDelegationAmount
-            }
-            InvalidTransactionV1::UnsupportedInvocationTarget { .. } => {
-                ErrorCode::UnsupportedInvocationTarget
             }
             InvalidTransactionV1::MissingSeed => ErrorCode::InvalidTransactionMissingSeed,
             _other => ErrorCode::InvalidTransactionUnspecified,

--- a/executor/wasm/src/lib.rs
+++ b/executor/wasm/src/lib.rs
@@ -25,7 +25,7 @@ use casper_executor_wasm_interface::{
         AuctionMethods, ControlMethods, CryptoMethods, EmitMethods, ExecuteError, ExecuteRequest,
         ExecuteRequestBuilder, ExecuteResult, ExecuteWithProviderError, ExecuteWithProviderResult,
         ExecutionKind, Executor, FFIMenu, GlobalStateMethods, IOMethods, MintMethods,
-        SystemContractMenu,
+        PackagePointer, SystemContractMenu,
     },
     install::{
         InstallContractError, InstallContractRequest, InstallContractResult,
@@ -47,6 +47,7 @@ use casper_types::{
     account::AccountHash,
     addressable_entity::{
         ActionThresholds, AssociatedKeys, EntityEntryPoint, EntryPoints as EntityEntryPoints,
+        NamedKeyAddr,
     },
     bytesrepr::{self, ToBytes},
     contract_messages::{MessageAddr, MessageTopicSummary},
@@ -57,13 +58,13 @@ use casper_types::{
     execution::RetValue,
     AddressableEntity, AuctionCosts, ByteCode, ByteCodeAddr, ByteCodeHash, ByteCodeKind, CLType,
     CLValue, Contract, ContractRuntimeTag, ContractWasmHash, Digest, EntityAddr,
-    EntityEntryPointV2, EntityEntryPointV2Flags, EntityKind, EntryPointAccess, EntryPointAddr,
-    EntryPointPayment, EntryPointType, EntryPointValue, Gas, Groups, HostFFIFunctionCost,
-    InitiatorAddr, Key, MessageLimits, MintCosts, NamedKeys, Package, PackageAddr, PackageStatus,
-    Parameter, Parameters, Phase, ProtocolVersion, StorageCosts, StoredValue, TransactionHash,
-    TransactionInvocationTarget, TypeDefinition, TypeDefinitionKind, TypeEnumVariant,
-    TypePrimitive, TypeStructField, TypeUid, URef, WasmV2Config, NAME_FOR_V2_CONTRACT_MAIN_PURSE,
-    U512,
+    EntityEntryPointV2, EntityEntryPointV2Flags, EntityKind, EntityVersion, EntityVersionKey,
+    EntityVersions, EntryPointAccess, EntryPointAddr, EntryPointPayment, EntryPointType,
+    EntryPointValue, Gas, Groups, HashAddr, HostFFIFunctionCost, InitiatorAddr, Key, MessageLimits,
+    MintCosts, NamedKeys, Package, PackageAddr, PackageStatus, Parameter, Parameters, Phase,
+    ProtocolVersion, StorageCosts, StoredValue, TransactionHash, TransactionInvocationTarget,
+    TypeDefinition, TypeDefinitionKind, TypeEnumVariant, TypePrimitive, TypeStructField, TypeUid,
+    URef, WasmV2Config, NAME_FOR_V2_CONTRACT_MAIN_PURSE, U512,
 };
 use tracing::{debug, error, info, trace, warn};
 
@@ -322,12 +323,28 @@ impl ExecutorV2 {
             if let ExecutionKind::SessionBytes(wasm_bytes) = &execution_kind {
                 (wasm_bytes.clone(), DEFAULT_WASM_ENTRY_POINT)
             } else if let ExecutionKind::Stored {
-                address: contract_package_addr,
+                package_pointer,
                 entry_point,
+                version,
+                protocol_version_major,
             } = &execution_kind
             {
-                let smart_contract_key = Key::Package((*contract_package_addr).into());
-                let vm1_key = Key::Hash(*contract_package_addr);
+                let contract_package_addr = if let Some(contract_package_addr) = self
+                    .resolve_stored_package_hash(package_pointer, &caller_key, &mut tracking_copy)
+                {
+                    contract_package_addr
+                } else {
+                    return Ok(ExecuteResult {
+                        host_error: Some(CallError::CodeNotFound),
+                        output: None,
+                        gas_usage: GasUsage::new(gas_limit, gas_limit),
+                        effects: tracking_copy.effects(),
+                        cache: tracking_copy.cache(),
+                        messages: tracking_copy.messages(),
+                    });
+                };
+                let smart_contract_key = Key::Package(contract_package_addr.into());
+                let vm1_key = Key::Hash(contract_package_addr);
 
                 let contract = match tracking_copy
                     .read_first(&[&vm1_key, &smart_contract_key])
@@ -339,28 +356,28 @@ impl ExecutorV2 {
                         ExecuteError::Fatal(FatalHostError::TrackingCopy)
                     })? {
                     Some(StoredValue::SmartContract(smart_contract_package)) => {
-                        let enabled_versions = smart_contract_package.enabled_versions();
-                        let maybe_contract_hash = enabled_versions.latest();
-                        let contract_hash = if let Some(contract_hash) = maybe_contract_hash {
-                            contract_hash
-                        } else {
-                            //#TODO this probably should not be a node stopping error?
-                            error!(
-                            "Couldn't find an active version for smart contract under path {:?}",
-                            [&vm1_key, &smart_contract_key]
+                        let package: Package = smart_contract_package;
+                        let res = self.determine_hash_addr_based_on_versions(
+                            &package,
+                            *protocol_version_major,
+                            *version,
                         );
-                            return Ok(ExecuteResult {
-                                host_error: Some(CallError::NoActiveContract),
-                                output: None,
-                                gas_usage: GasUsage::new(gas_limit, gas_limit),
-                                effects: tracking_copy.effects(),
-                                cache: tracking_copy.cache(),
-                                messages: tracking_copy.messages(),
-                            });
+                        let contract_hash = match res {
+                            Ok(hash) => hash,
+                            Err(call_error) => {
+                                return Ok(ExecuteResult {
+                                    host_error: Some(call_error),
+                                    output: None,
+                                    gas_usage: GasUsage::new(gas_limit, gas_limit),
+                                    effects: tracking_copy.effects(),
+                                    cache: tracking_copy.cache(),
+                                    messages: tracking_copy.messages(),
+                                });
+                            }
                         };
-                        let entity_addr = EntityAddr::SmartContract(contract_hash.value());
+                        let entity_addr = EntityAddr::SmartContract(contract_hash);
                         let latest_version_key = Key::AddressableEntity(entity_addr);
-                        assert_eq!(&entity_addr.value(), contract_package_addr);
+                        assert_eq!(entity_addr.value(), contract_package_addr);
                         tracking_copy
                             .read(&latest_version_key)
                             .map_err(|read_err| {
@@ -369,30 +386,30 @@ impl ExecutorV2 {
                             })?
                     }
                     Some(StoredValue::ContractPackage(smart_contract_package)) => {
-                        let contract_hash = if let Some((_, contract_hash)) =
-                            smart_contract_package.enabled_versions().iter().last()
-                        {
-                            *contract_hash
-                        } else {
-                            //#TODO this probably should not be a node stopping error?
-                            error!(
-                            "Couldn't find an active version for smart contract under path {:?}",
-                            [&vm1_key, &smart_contract_key]
+                        let package: Package = smart_contract_package.into();
+                        let res = self.determine_hash_addr_based_on_versions(
+                            &package,
+                            *protocol_version_major,
+                            *version,
                         );
-                            return Ok(ExecuteResult {
-                                host_error: Some(CallError::NoActiveContract),
-                                output: None,
-                                gas_usage: GasUsage::new(gas_limit, gas_limit),
-                                effects: tracking_copy.effects(),
-                                cache: tracking_copy.cache(),
-                                messages: tracking_copy.messages(),
-                            });
+                        let contract_hash = match res {
+                            Ok(hash) => hash,
+                            Err(call_error) => {
+                                return Ok(ExecuteResult {
+                                    host_error: Some(call_error),
+                                    output: None,
+                                    gas_usage: GasUsage::new(gas_limit, gas_limit),
+                                    effects: tracking_copy.effects(),
+                                    cache: tracking_copy.cache(),
+                                    messages: tracking_copy.messages(),
+                                });
+                            }
                         };
-                        let latest_version_key = Key::Hash(contract_hash.value());
+                        let matching_contract_key = Key::Hash(contract_hash);
                         tracking_copy
-                            .read(&latest_version_key)
+                            .read(&matching_contract_key)
                             .map_err(|read_err| {
-                                error!("Error when fetching smart contract {latest_version_key}. Details {read_err}");
+                                error!("Error when fetching smart contract {matching_contract_key}. Details {read_err}");
                                 ExecuteError::Fatal(FatalHostError::TrackingCopy)
                             })?
                     }
@@ -416,7 +433,7 @@ impl ExecutorV2 {
                                     self.execution_engine_v1.config().protocol_version(),
                                 );
 
-                                let entity_addr = EntityAddr::Package(*contract_package_addr);
+                                let entity_addr = EntityAddr::Package(contract_package_addr);
 
                                 return self.execute_vm1_wasm_byte_code(
                                     initiator,
@@ -639,7 +656,7 @@ impl ExecutorV2 {
                                     self.execution_engine_v1.config().protocol_version(),
                                 );
 
-                                let entity_addr = EntityAddr::SmartContract(*contract_package_addr);
+                                let entity_addr = EntityAddr::SmartContract(contract_package_addr);
 
                                 return self.execute_vm1_wasm_byte_code(
                                     initiator,
@@ -691,14 +708,28 @@ impl ExecutorV2 {
         // Derive callee key from the execution target.
         let (callee_key, entry_point_name) = match &execution_kind {
             ExecutionKind::Stored {
-                address: smart_contract_package_addr,
+                package_pointer,
                 entry_point,
                 ..
             } => {
-                let key = if tracking_copy.addressable_entity_enabled() {
-                    Key::Package((*smart_contract_package_addr).into())
+                let contract_package_addr = if let Some(contract_package_addr) = self
+                    .resolve_stored_package_hash(package_pointer, &caller_key, &mut tracking_copy)
+                {
+                    contract_package_addr
                 } else {
-                    Key::Hash(*smart_contract_package_addr)
+                    return Ok(ExecuteResult {
+                        host_error: Some(CallError::CodeNotFound),
+                        output: None,
+                        gas_usage: GasUsage::new(gas_limit, gas_limit),
+                        effects: tracking_copy.effects(),
+                        cache: tracking_copy.cache(),
+                        messages: tracking_copy.messages(),
+                    });
+                };
+                let key = if tracking_copy.addressable_entity_enabled() {
+                    Key::Package(contract_package_addr.into())
+                } else {
+                    Key::Hash(contract_package_addr)
                 };
                 (key, entry_point.clone())
             }
@@ -971,6 +1002,9 @@ impl ExecutorV2 {
                         GlobalStateMethods::Create => {
                             config.wasm_config.host_ffi_opt_costs().create
                         }
+                        GlobalStateMethods::StorePackageUnderKey => {
+                            config.wasm_config.host_ffi_opt_costs().write
+                        }
                     },
                     FFIMenu::Control(control_methods) => match control_methods {
                         ControlMethods::Call => config.wasm_config.host_ffi_opt_costs().call,
@@ -1148,6 +1182,144 @@ impl ExecutorV2 {
             },
             Err(error) => Err(ExecuteWithProviderError::Execute(error)),
         }
+    }
+
+    fn determine_hash_addr_based_on_versions(
+        &self,
+        package: &Package,
+        protocol_version_major: Option<u32>,
+        version: Option<u32>,
+    ) -> Result<HashAddr, CallError> {
+        let enabled_versions = package.enabled_versions();
+        let entity_version_key = match (version, protocol_version_major) {
+            (Some(entity_version), Some(major)) => EntityVersionKey::new(major, entity_version),
+            (None, Some(major)) => package.current_entity_version_for(major),
+            (Some(entity_version), None) => {
+                match self
+                    .get_protocol_version_for_entity_version(entity_version, &enabled_versions)
+                {
+                    Ok(entity_version_key) => entity_version_key,
+                    Err(err) => {
+                        return Err(err);
+                    }
+                }
+            }
+            (None, None) => match package.current_entity_version() {
+                Some(v) => v,
+                None => {
+                    return Err(CallError::NoActiveContract);
+                }
+            },
+        };
+        if package.is_version_missing(entity_version_key) {
+            return Err(CallError::NoActiveContract);
+        }
+
+        if !package.is_version_enabled(entity_version_key) {
+            return Err(CallError::NoActiveContract);
+        }
+
+        Ok(package
+            .lookup_entity_hash(entity_version_key)
+            .copied()
+            .ok_or(CallError::NoActiveContract)?
+            .value())
+    }
+
+    fn get_protocol_version_for_entity_version(
+        &self,
+        entity_version: EntityVersion,
+        enabled_versions: &EntityVersions,
+    ) -> Result<EntityVersionKey, CallError> {
+        let current_protocol_version_major = self
+            .execution_engine_v1
+            .config()
+            .protocol_version()
+            .destructure()
+            .0;
+
+        let mut possible_versions = vec![];
+
+        for protocol_version_major in (1..=current_protocol_version_major).rev() {
+            let entity_version_key = EntityVersionKey::new(protocol_version_major, entity_version);
+            // If there is a corresponding addr then its an enabled valid entity version key
+            if enabled_versions.get(&entity_version_key).is_some() {
+                possible_versions.push(entity_version_key)
+            }
+        }
+
+        if possible_versions.len() > 1
+            && self
+                .execution_engine_v1
+                .config()
+                .trap_on_ambiguous_entity_version()
+        {
+            return Err(CallError::NoActiveContract);
+        }
+
+        // If possible versions has more than one, then the element to be popped
+        // will be the version key which has the same entity version, but the highest protocol
+        // version If there is only one version key matching the entity version then we will
+        // correctly pop the singular element in the possible versions.
+        // This sort is load bearing.
+        possible_versions.sort();
+        if let Some(possible_version) = possible_versions.pop() {
+            Ok(possible_version)
+        } else {
+            Err(CallError::NoActiveContract)
+        }
+    }
+
+    fn resolve_stored_package_hash<R: GlobalStateReader + 'static>(
+        &self,
+        package_pointer: &PackagePointer,
+        caller_key: &Key,
+        tracking_copy: &mut TrackingCopy<R>,
+    ) -> Option<HashAddr> {
+        let contract_package_addr = match package_pointer {
+            PackagePointer::HashAddr(hash_addr) => *hash_addr,
+            PackagePointer::NamedKeyName(name) => {
+                let global_state_key = match caller_key {
+                    Key::Account(_) => *caller_key,
+                    Key::Hash(_) => *caller_key,
+                    Key::AddressableEntity(entity_addr) => {
+                        let digest = Digest::hash(name.as_bytes());
+                        Key::NamedKey(NamedKeyAddr::new_named_key_entry(
+                            *entity_addr,
+                            digest.value(),
+                        ))
+                    }
+                    _ => {
+                        // This should never happen, as the caller is always an account or a smart
+                        // contract.
+                        panic!("Unexpected callee variant: {:?}", caller_key)
+                    }
+                };
+                let global_state_read_result = tracking_copy.read(&global_state_key);
+                let maybe_named_key = match global_state_read_result {
+                    Ok(Some(StoredValue::NamedKey(named_key_value))) => {
+                        print!("XXXXXX {:?}", named_key_value.get_key_as_cl_value());
+                        panic!("DUPAZUPA");
+                    }
+                    Ok(Some(StoredValue::Account(account))) => {
+                        account.named_keys().get(name).cloned()
+                    }
+                    Ok(Some(StoredValue::Contract(contract))) => {
+                        contract.named_keys().get(name).cloned()
+                    }
+                    _ => None,
+                };
+                match maybe_named_key {
+                    Some(key) => match key {
+                        Key::Package(package_addr) => package_addr.value(),
+                        Key::Hash(package_addr) => package_addr,
+                        _ => return None,
+                    },
+                    None => return None,
+                }
+            }
+        };
+        Some(contract_package_addr)
     }
 }
 
@@ -1758,8 +1930,10 @@ impl Executor for ExecutorV2 {
                 .with_initiator(initiator)
                 .with_caller_key(caller_key)
                 .with_execution_kind(ExecutionKind::Stored {
-                    address: package_addr,
+                    package_pointer: PackagePointer::HashAddr(package_addr),
                     entry_point: entry_point_name,
+                    version: None,
+                    protocol_version_major: None,
                 })
                 .with_gas_limit(state.gas_usage.remaining_points())
                 .with_input(input)

--- a/executor/wasm/tests/altbn128.rs
+++ b/executor/wasm/tests/altbn128.rs
@@ -7,7 +7,9 @@ use casper_executor_wasm::testing::{
 };
 
 use casper_executor_wasm::{chainspec_config, chainspec_config::ChainspecConfig};
-use casper_executor_wasm_interface::executor::{ExecuteWithProviderError, ExecutionKind};
+use casper_executor_wasm_interface::executor::{
+    ExecuteWithProviderError, ExecutionKind, PackagePointer,
+};
 use casper_storage::global_state::state::CommitProvider;
 use once_cell::sync::Lazy;
 
@@ -174,8 +176,10 @@ fn run_pairing_endpoint_test<T: BorshSerialize>(
         .with_shared_address_generator(Arc::clone(&address_generator))
         .with_transferred_value(0)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_address,
+            package_pointer: PackagePointer::HashAddr(contract_address),
             entry_point: "pairing".to_owned(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_serialized_input(input)
         .expect("expected serialized input to be correct")

--- a/executor/wasm/tests/collections.rs
+++ b/executor/wasm/tests/collections.rs
@@ -10,7 +10,7 @@ use casper_executor_wasm::{
 };
 
 use casper_executor_wasm::{chainspec_config, chainspec_config::ChainspecConfig};
-use casper_executor_wasm_interface::executor::ExecutionKind;
+use casper_executor_wasm_interface::executor::{ExecutionKind, PackagePointer};
 use casper_storage::global_state::state::CommitProvider;
 use once_cell::sync::Lazy;
 
@@ -77,8 +77,10 @@ fn should_run_test_suite() {
         .with_shared_address_generator(Arc::clone(&address_generator))
         .with_transferred_value(0)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_address,
+            package_pointer: PackagePointer::HashAddr(contract_address),
             entry_point: "assertions".to_owned(),
+            version: None,
+            protocol_version_major: None,
         })
         .build()
         .expect("should build");
@@ -145,8 +147,10 @@ fn inserting_into_non_existing_vec_index_fails() {
         .with_shared_address_generator(Arc::clone(&address_generator))
         .with_transferred_value(0)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_address,
+            package_pointer: PackagePointer::HashAddr(contract_address),
             entry_point: "test_remove_invalid_index_prepare".to_owned(),
+            version: None,
+            protocol_version_major: None,
         })
         .build()
         .expect("should build");

--- a/executor/wasm/tests/hello_world.rs
+++ b/executor/wasm/tests/hello_world.rs
@@ -10,8 +10,8 @@ use casper_executor_wasm::{
     ExecutorV2,
 };
 use casper_executor_wasm_interface::{
-    executor::ExecutionKind,
-    install::{InstallContractResult, InstallContractWithProviderResult},
+    executor::{ExecutionKind, PackagePointer},
+    install::InstallContractWithProviderResult,
 };
 use casper_storage::{
     data_access_layer::{QueryRequest, QueryResult},
@@ -95,8 +95,10 @@ fn should_store_state_after_changes() {
         .with_shared_address_generator(Arc::clone(&address_generator))
         .with_transferred_value(0)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_address,
+            package_pointer: PackagePointer::HashAddr(contract_address),
             entry_point: "spanish".to_owned(),
+            version: None,
+            protocol_version_major: None,
         })
         .build()
         .expect("should build");
@@ -115,8 +117,10 @@ fn should_store_state_after_changes() {
         .with_shared_address_generator(Arc::clone(&address_generator))
         .with_transferred_value(0)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_address,
+            package_pointer: PackagePointer::HashAddr(contract_address),
             entry_point: "french".to_owned(),
+            version: None,
+            protocol_version_major: None,
         })
         .build()
         .expect("should build");
@@ -176,8 +180,10 @@ fn should_fetch_data_with_contract_method() {
         .with_shared_address_generator(Arc::clone(&address_generator))
         .with_transferred_value(0)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_address,
+            package_pointer: PackagePointer::HashAddr(contract_address),
             entry_point: "spanish".to_owned(),
+            version: None,
+            protocol_version_major: None,
         })
         .build()
         .expect("should build");
@@ -196,8 +202,10 @@ fn should_fetch_data_with_contract_method() {
         .with_shared_address_generator(Arc::clone(&address_generator))
         .with_transferred_value(0)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_address,
+            package_pointer: PackagePointer::HashAddr(contract_address),
             entry_point: "get".to_owned(),
+            version: None,
+            protocol_version_major: None,
         })
         .build()
         .expect("should build");

--- a/executor/wasm/tests/integration.rs
+++ b/executor/wasm/tests/integration.rs
@@ -26,7 +26,7 @@ use casper_executor_wasm_common::error::CallError;
 use casper_executor_wasm_interface::{
     executor::{
         AuctionMethods, ExecuteError, ExecuteRequest, ExecuteWithProviderError, ExecutionKind,
-        FFIMenu, MintMethods,
+        FFIMenu, MintMethods, PackagePointer,
     },
     install::{InstallContractError, InstallContractRequest},
 };
@@ -113,8 +113,10 @@ fn vm2_should_return_output_to_caller() {
         .with_gas_limit(DEFAULT_GAS_LIMIT)
         .with_transaction_hash(TRANSACTION_HASH)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_hash.value(),
+            package_pointer: PackagePointer::HashAddr(contract_hash.value()),
             entry_point: "entry_point_without_state_with_args_and_output".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_transferred_value(0)
         .with_shared_address_generator(Arc::clone(&address_generator))
@@ -176,8 +178,10 @@ fn vm2_rollback_should_return_to_caller_with_data() {
         .with_gas_limit(DEFAULT_GAS_LIMIT)
         .with_transaction_hash(TRANSACTION_HASH)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_hash.value(),
+            package_pointer: PackagePointer::HashAddr(contract_hash.value()),
             entry_point: "emit_rollback_with_data".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_transferred_value(0)
         .with_shared_address_generator(Arc::clone(&address_generator))
@@ -240,8 +244,10 @@ fn vm2_revert_should_abort_whole_stack() {
         .with_gas_limit(DEFAULT_GAS_LIMIT)
         .with_transaction_hash(TRANSACTION_HASH)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_hash.value(),
+            package_pointer: PackagePointer::HashAddr(contract_hash.value()),
             entry_point: "emit_revert".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_transferred_value(0)
         .with_shared_address_generator(Arc::clone(&address_generator))
@@ -942,8 +948,10 @@ fn counter() {
         .with_gas_limit(DEFAULT_GAS_LIMIT)
         .with_transaction_hash(TRANSACTION_HASH)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_hash.value(),
+            package_pointer: PackagePointer::HashAddr(contract_hash.value()),
             entry_point: "increment".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_transferred_value(0)
         .with_shared_address_generator(Arc::clone(&address_generator))
@@ -974,8 +982,10 @@ fn counter() {
         .with_gas_limit(DEFAULT_GAS_LIMIT)
         .with_transaction_hash(TRANSACTION_HASH)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_hash.value(),
+            package_pointer: PackagePointer::HashAddr(contract_hash.value()),
             entry_point: "get".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_transferred_value(0)
         .with_shared_address_generator(Arc::clone(&address_generator))
@@ -1035,8 +1045,10 @@ fn counter() {
         .with_gas_limit(DEFAULT_GAS_LIMIT)
         .with_transaction_hash(TRANSACTION_HASH)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_hash.value(),
+            package_pointer: PackagePointer::HashAddr(contract_hash.value()),
             entry_point: "decrement".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_transferred_value(0)
         .with_shared_address_generator(Arc::clone(&address_generator))
@@ -1158,8 +1170,10 @@ fn upgradable() {
     let version_before_upgrade = {
         let execute_request = base_execute_builder(&chainspec_config)
             .with_execution_kind(ExecutionKind::Stored {
-                address: upgradable_address,
+                package_pointer: PackagePointer::HashAddr(upgradable_address),
                 entry_point: "version".to_string(),
+                version: None,
+                protocol_version_major: None,
             })
             .with_input(Bytes::new())
             .with_gas_limit(DEFAULT_GAS_LIMIT)
@@ -1183,8 +1197,10 @@ fn upgradable() {
         // Increment the value
         let execute_request = base_execute_builder(&chainspec_config)
             .with_execution_kind(ExecutionKind::Stored {
-                address: upgradable_address,
+                package_pointer: PackagePointer::HashAddr(upgradable_address),
                 entry_point: "increment".to_string(),
+                version: None,
+                protocol_version_major: None,
             })
             .with_input(Bytes::new())
             .with_gas_limit(DEFAULT_GAS_LIMIT)
@@ -1209,8 +1225,10 @@ fn upgradable() {
     let execute_request = base_execute_builder(&chainspec_config)
         .with_transferred_value(0)
         .with_execution_kind(ExecutionKind::Stored {
-            address: upgradable_address,
+            package_pointer: PackagePointer::HashAddr(upgradable_address),
             entry_point: "perform_upgrade".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_gas_limit(DEFAULT_GAS_LIMIT)
         .with_serialized_input((new_code,))
@@ -1231,8 +1249,10 @@ fn upgradable() {
     let version_after_upgrade = {
         let execute_request = base_execute_builder(&chainspec_config)
             .with_execution_kind(ExecutionKind::Stored {
-                address: upgradable_address,
+                package_pointer: PackagePointer::HashAddr(upgradable_address),
                 entry_point: "version".to_string(),
+                version: None,
+                protocol_version_major: None,
             })
             .with_input(Bytes::new())
             .with_gas_limit(DEFAULT_GAS_LIMIT)
@@ -1256,8 +1276,10 @@ fn upgradable() {
         // Increment the value
         let execute_request = base_execute_builder(&chainspec_config)
             .with_execution_kind(ExecutionKind::Stored {
-                address: upgradable_address,
+                package_pointer: PackagePointer::HashAddr(upgradable_address),
                 entry_point: "increment_by".to_string(),
+                version: None,
+                protocol_version_major: None,
             })
             .with_serialized_input((10u64,))
             .expect("expected serialized input to be correct")
@@ -1398,8 +1420,10 @@ fn backwards_compatibility() {
 
     let call_request = base_execute_builder(&chainspec_config)
         .with_execution_kind(ExecutionKind::Stored {
-            address: proxy_address,
+            package_pointer: PackagePointer::HashAddr(proxy_address),
             entry_point: "perform_test".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_input(Bytes::new())
         .with_gas_limit(DEFAULT_GAS_LIMIT)
@@ -1473,8 +1497,10 @@ fn non_existing_smart_contract_does_not_panic() {
     let non_existing_address = [255; 32];
     let execute_request = base_execute_builder(&chainspec_config)
         .with_execution_kind(ExecutionKind::Stored {
-            address: non_existing_address,
+            package_pointer: PackagePointer::HashAddr(non_existing_address),
             entry_point: "non_existing".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_input(Bytes::new())
         .with_gas_limit(DEFAULT_GAS_LIMIT)
@@ -1530,8 +1556,10 @@ fn casper_return_writes_to_execution_journal() {
     // Execute the contract to trigger the return
     let execute_request = base_execute_builder(&chainspec_config)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_address,
+            package_pointer: PackagePointer::HashAddr(contract_address),
             entry_point: "ret".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_input(Bytes::new())
         .with_gas_limit(DEFAULT_GAS_LIMIT)
@@ -1621,8 +1649,10 @@ fn casper_return_fails_if_contract_uses_unsupported_flags() {
     // Execute the contract to trigger the return
     let execute_request = base_execute_builder(&chainspec_config)
         .with_execution_kind(ExecutionKind::Stored {
-            address: contract_address,
+            package_pointer: PackagePointer::HashAddr(contract_address),
             entry_point: "ret_faulty_flags".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_input(Bytes::new())
         .with_gas_limit(DEFAULT_GAS_LIMIT)
@@ -1692,8 +1722,10 @@ fn escrow() {
         .with_gas_limit(DEFAULT_GAS_LIMIT)
         .with_transaction_hash(TRANSACTION_HASH)
         .with_execution_kind(ExecutionKind::Stored {
-            address: *contract_hash,
+            package_pointer: PackagePointer::HashAddr(*contract_hash),
             entry_point: "deposit_tokens".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_serialized_input(())
         .expect("expected serialized input to be correct")
@@ -1818,8 +1850,10 @@ fn supports_named_args_convention() {
         .with_gas_limit(DEFAULT_GAS_LIMIT)
         .with_transaction_hash(TRANSACTION_HASH)
         .with_execution_kind(ExecutionKind::Stored {
-            address: *contract_hash,
+            package_pointer: PackagePointer::HashAddr(*contract_hash),
             entry_point: "deposit_tokens".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_serialized_input(())
         .unwrap()
@@ -1990,8 +2024,10 @@ fn installing_contract_should_produce_system_messages_after_upgrade() {
     let execute_request = base_execute_builder(&chainspec_config)
         .with_transferred_value(0)
         .with_execution_kind(ExecutionKind::Stored {
-            address: upgradable_address,
+            package_pointer: PackagePointer::HashAddr(upgradable_address),
             entry_point: "perform_upgrade".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_gas_limit(DEFAULT_GAS_LIMIT)
         .with_serialized_input((new_code,))
@@ -2116,8 +2152,10 @@ fn calling_upgrade_contract_should_produce_ret_and_call_result() {
     let execute_request = base_execute_builder(&chainspec_config)
         .with_transferred_value(0)
         .with_execution_kind(ExecutionKind::Stored {
-            address: upgradable_address,
+            package_pointer: PackagePointer::HashAddr(upgradable_address),
             entry_point: "perform_upgrade".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_gas_limit(DEFAULT_GAS_LIMIT * 10)
         .with_serialized_input((new_code,))
@@ -2291,8 +2329,10 @@ fn contract_calling_different_contract_should_produce_ret_and_call_result() {
         .with_gas_limit(DEFAULT_GAS_LIMIT)
         .with_transaction_hash(TRANSACTION_HASH)
         .with_execution_kind(ExecutionKind::Stored {
-            address: *caller_create_result.smart_contract_addr(),
+            package_pointer: PackagePointer::HashAddr(*caller_create_result.smart_contract_addr()),
             entry_point: "inc_and_get".to_string(),
+            version: None,
+            protocol_version_major: None,
         })
         .with_transferred_value(0)
         .with_shared_address_generator(Arc::clone(&address_generator))

--- a/executor/wasm_common/src/keyspace.rs
+++ b/executor/wasm_common/src/keyspace.rs
@@ -101,7 +101,7 @@ pub enum Keyspace<'a> {
     /// Structured context address.
     Context(ContextAddr),
     /// Human-readable named key.
-    NamedKey(&'a str),
+    NamedValue(&'a str),
     /// Retrieves contract's type definitions.
     TypeDef(Uid),
     /// Stores contract's entry points.
@@ -113,7 +113,7 @@ impl Keyspace<'_> {
     pub fn as_tag(&self) -> KeyspaceTag {
         match self {
             Keyspace::Context(_) => KeyspaceTag::Context,
-            Keyspace::NamedKey(_) => KeyspaceTag::NamedKey,
+            Keyspace::NamedValue(_) => KeyspaceTag::NamedKey,
             Keyspace::TypeDef(_) => KeyspaceTag::TypeDef,
             Keyspace::EntryPoint(_) => KeyspaceTag::EntryPoint,
         }
@@ -129,15 +129,15 @@ impl Keyspace<'_> {
             Keyspace::Context(key_bytes) => {
                 borsh::to_vec(&(KeyspaceTag::Context as u64, borsh::to_vec(key_bytes)?))
             }
-            Keyspace::NamedKey(key_bytes) => {
-                borsh::to_vec(&(KeyspaceTag::NamedKey as u64, key_bytes.as_bytes()))
-            }
             Keyspace::TypeDef(typedef) => borsh::to_vec(&(
                 KeyspaceTag::TypeDef as u64,
                 typedef.into_raw().to_le_bytes().to_vec(),
             )),
             Keyspace::EntryPoint(entry_point_name) => {
                 borsh::to_vec(&(KeyspaceTag::EntryPoint as u64, entry_point_name))
+            }
+            Keyspace::NamedValue(key_bytes) => {
+                borsh::to_vec(&(KeyspaceTag::NamedKey as u64, key_bytes.as_bytes()))
             }
         }
     }
@@ -150,55 +150,43 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_as_tag_state() {
-        let keyspace = Keyspace::State;
-        assert_eq!(keyspace.as_tag(), KeyspaceTag::State);
-    }
-
-    #[test]
     fn test_as_tag_context() {
-        let data = [1, 2, 3];
-        let keyspace = Keyspace::Context(&data);
+        let context_addr = ContextAddr::StateAddr(StateAddrInner::new("abc"));
+        let keyspace = Keyspace::Context(context_addr);
         assert_eq!(keyspace.as_tag(), KeyspaceTag::Context);
     }
 
     #[test]
     fn test_as_tag_named_key() {
         let name = "my_key";
-        let keyspace = Keyspace::NamedKey(name);
+        let keyspace = Keyspace::NamedValue(name);
         assert_eq!(keyspace.as_tag(), KeyspaceTag::NamedKey);
     }
 
     #[test]
-    fn test_as_u64_state() {
-        let keyspace = Keyspace::State;
-        assert_eq!(keyspace.as_u64(), 0);
-    }
-
-    #[test]
     fn test_as_u64_context() {
-        let data = [1, 2, 3];
-        let keyspace = Keyspace::Context(&data);
-        assert_eq!(keyspace.as_u64(), 1);
+        let context_addr = ContextAddr::StateAddr(StateAddrInner::new("abc"));
+        let keyspace = Keyspace::Context(context_addr);
+        assert_eq!(keyspace.as_u64(), 0);
     }
 
     #[test]
     fn test_as_u64_named_key() {
         let name = "my_key";
-        let keyspace = Keyspace::NamedKey(name);
+        let keyspace = Keyspace::NamedValue(name);
         assert_eq!(keyspace.as_u64(), 2);
     }
 
     #[test]
-    fn test_as_u64_all_named_keys() {
+    fn test_as_u64_type_def() {
         let keyspace = Keyspace::TypeDef(Uid::from_name("foobar"));
-        assert_eq!(keyspace.as_u64(), 4);
+        assert_eq!(keyspace.as_u64(), 3);
     }
 
     #[test]
     fn test_as_u64_entry_point() {
         let name = "my_entry_point";
         let keyspace = Keyspace::EntryPoint(name);
-        assert_eq!(keyspace.as_u64(), 5);
+        assert_eq!(keyspace.as_u64(), 4);
     }
 }

--- a/executor/wasm_host/src/host.rs
+++ b/executor/wasm_host/src/host.rs
@@ -30,7 +30,8 @@ use crate::{
         },
         emit::{emit, print_std},
         global_state::{
-            host_create, host_env_balance, host_env_info, host_read, host_remove, host_write,
+            host_create, host_env_balance, host_env_info, host_read, host_remove,
+            host_store_package_under_key, host_write,
         },
         io::{host_copy_input, host_return, host_revert},
     },
@@ -193,6 +194,9 @@ pub fn casper_ffi<S: GlobalStateReader + 'static>(
             GlobalStateMethods::GetBalance => host_env_balance(&mut caller, input_data),
             GlobalStateMethods::GetInfo => host_env_info(&mut caller),
             GlobalStateMethods::Create => host_create(&mut caller, input_data),
+            GlobalStateMethods::StorePackageUnderKey => {
+                host_store_package_under_key(&mut caller, input_data).map(|code| (None, code))
+            }
         },
         FFIMenu::Control(control_methods) => match control_methods {
             ControlMethods::Call => host_call(&mut caller, input_data),

--- a/executor/wasm_host/src/host/control.rs
+++ b/executor/wasm_host/src/host/control.rs
@@ -9,7 +9,9 @@ use casper_executor_wasm_common::{
     },
 };
 use casper_executor_wasm_interface::{
-    executor::{ExecuteError, ExecuteRequestBuilder, ExecuteResult, ExecutionKind, Executor},
+    executor::{
+        ExecuteError, ExecuteRequestBuilder, ExecuteResult, ExecutionKind, Executor, PackagePointer,
+    },
     Caller, FatalHostError, VMError, VMResult,
 };
 use casper_storage::global_state::GlobalStateReader;
@@ -31,15 +33,30 @@ pub(crate) fn host_call<S: GlobalStateReader + 'static>(
     caller: &mut impl Caller<Context = Context<S>>,
     input: Bytes,
 ) -> VMResult<(Option<Bytes>, u32)> {
-    let (smart_contract_addr, input_data, entry_point_name, transferred_value) =
-        match bytesrepr::deserialize_from_slice::<&Bytes, (HashAddr, BytesreprBytes, String, u64)>(
-            &input,
-        ) {
-            Ok(res) => res,
-            Err(_) => {
-                return Ok((None, CALLEE_INPUT_INVALID));
-            }
-        };
+    let (
+        smart_contract_addr,
+        input_data,
+        entry_point_name,
+        transferred_value,
+        version,
+        protocol_version_major,
+    ) = match bytesrepr::deserialize_from_slice::<
+        &Bytes,
+        (
+            HashAddr,
+            BytesreprBytes,
+            String,
+            u64,
+            Option<u32>,
+            Option<u32>,
+        ),
+    >(&input)
+    {
+        Ok(res) => res,
+        Err(_) => {
+            return Ok((None, CALLEE_INPUT_INVALID));
+        }
+    };
     // 1. Look up address in the storage
     // 1a. if it's VM1 contract, wire up old EE, pretend you're 1.x. Input data would be
     // "RuntimeArgs". Serialized output of the call has to be passed as output. Value is ignored as
@@ -64,8 +81,10 @@ pub(crate) fn host_call<S: GlobalStateReader + 'static>(
         .with_caller_key(caller.context().callee)
         .with_gas_limit(gas_limit)
         .with_execution_kind(ExecutionKind::Stored {
-            address: smart_contract_addr,
+            package_pointer: PackagePointer::HashAddr(smart_contract_addr),
             entry_point: entry_point_name.clone(),
+            version,
+            protocol_version_major,
         })
         .with_transferred_value(transferred_value)
         .with_input(input_data)
@@ -380,8 +399,10 @@ pub(crate) fn host_upgrade<S: GlobalStateReader + 'static>(
             .with_caller_key(caller.context().callee)
             .with_gas_limit(gas_limit)
             .with_execution_kind(ExecutionKind::Stored {
-                address: smart_contract_addr,
+                package_pointer: PackagePointer::HashAddr(smart_contract_addr),
                 entry_point: entry_point_name.clone(),
+                version: None,
+                protocol_version_major: None,
             })
             .with_input(input_data.unwrap_or_default())
             // Upgrade entry point is executed with zero value as it does not seem to make sense to

--- a/executor/wasm_host/src/host/global_state.rs
+++ b/executor/wasm_host/src/host/global_state.rs
@@ -41,54 +41,16 @@ pub(crate) fn host_read<S: GlobalStateReader + 'static>(
     caller: &mut impl Caller<Context = Context<S>>,
     input: Bytes,
 ) -> VMResult<(Option<Bytes>, u32)> {
-    let (key_tag, key_payload_bytes) =
+    let (raw_keyspace_tag, key_payload_bytes) =
         match bytesrepr::deserialize_from_slice::<&Bytes, (u64, BytesreprBytes)>(&input) {
             Ok(res) => res,
             Err(_) => {
                 return Ok((None, HOST_ERROR_INVALID_INPUT));
             }
         };
-    let keyspace_tag = match KeyspaceTag::from_u64(key_tag) {
-        Some(keyspace_tag) => keyspace_tag,
-        None => {
-            // Unknown keyspace received, return error
-            return Ok((None, HOST_ERROR_INVALID_INPUT));
-        }
-    };
-
-    let keyspace = match keyspace_tag {
-        KeyspaceTag::Context => {
-            let ctx_addr: ContextAddr = match borsh::from_slice(&key_payload_bytes) {
-                Ok(v) => v,
-                Err(_) => {
-                    return Ok((None, HOST_ERROR_INVALID_INPUT));
-                }
-            };
-            Keyspace::Context(ctx_addr)
-        }
-        KeyspaceTag::NamedKey => {
-            let key_name = match std::str::from_utf8(&key_payload_bytes) {
-                Ok(key_name) => key_name,
-                Err(_) => {
-                    return Ok((None, HOST_ERROR_INVALID_DATA));
-                }
-            };
-            Keyspace::NamedKey(key_name)
-        }
-        KeyspaceTag::TypeDef => match <[u8; 4]>::try_from(key_payload_bytes.as_slice()) {
-            Ok(array) => {
-                let u32_value = u32::from_le_bytes(array);
-                let uid = Uid::new_raw(u32_value);
-                Keyspace::TypeDef(uid)
-            }
-            Err(_) => {
-                error!("Invalid TypeDef Uid bytes length");
-                return Ok((None, HOST_ERROR_INVALID_DATA));
-            }
-        },
-        KeyspaceTag::EntryPoint => Keyspace::EntryPoint(
-            std::str::from_utf8(&key_payload_bytes).map_err(|_| FatalHostError::TypeConversion)?,
-        ),
+    let keyspace = match deserialize_keyspace(raw_keyspace_tag, &key_payload_bytes) {
+        Ok(keyspace) => keyspace,
+        Err(err_code) => return Ok((None, err_code)),
     };
 
     let global_state_key = match keyspace_to_global_state_key(caller.context(), keyspace.clone()) {
@@ -132,8 +94,37 @@ pub(crate) fn host_read<S: GlobalStateReader + 'static>(
             }
         }
         Ok(Some(StoredValue::Contract(contract))) => match keyspace {
-            Keyspace::NamedKey(name) => {
+            Keyspace::NamedValue(name) => {
                 let Some(Key::URef(uref)) = contract.named_keys().get(name) else {
+                    return Ok((None, HOST_ERROR_INVALID_DATA));
+                };
+
+                match caller.context_mut().tracking_copy.read(&Key::URef(*uref)) {
+                    Ok(Some(StoredValue::CLValue(cl_value))) => {
+                        let CLType::Any = cl_value.cl_type() else {
+                            return Ok((None, HOST_ERROR_INVALID_DATA));
+                        };
+                        Cow::Owned(cl_value.inner_bytes().to_owned())
+                    }
+                    Ok(Some(_)) => {
+                        return Ok((None, HOST_ERROR_INVALID_DATA));
+                    }
+                    Ok(None) => {
+                        return Ok((None, HOST_ERROR_NOT_FOUND));
+                    }
+                    Err(_error) => {
+                        return Err(FatalHostError::TrackingCopy.into());
+                    }
+                }
+            }
+            _ => {
+                error!(?keyspace, "unsupported keyspace");
+                return Ok((None, HOST_ERROR_INVALID_INPUT));
+            }
+        },
+        Ok(Some(StoredValue::Account(account))) => match keyspace {
+            Keyspace::NamedValue(name) => {
+                let Some(Key::URef(uref)) = account.named_keys().get(name) else {
                     return Ok((None, HOST_ERROR_INVALID_DATA));
                 };
 
@@ -209,7 +200,7 @@ pub(crate) fn host_write<S: GlobalStateReader + 'static>(
     caller: &mut impl Caller<Context = Context<S>>,
     input: Bytes,
 ) -> VMResult<u32> {
-    let (key_space, key_payload_bytes, value) =
+    let (raw_keyspace_tag, key_payload_bytes, value) =
         match bytesrepr::deserialize_from_slice::<&Bytes, (u64, BytesreprBytes, BytesreprBytes)>(
             &input,
         ) {
@@ -219,45 +210,9 @@ pub(crate) fn host_write<S: GlobalStateReader + 'static>(
             }
         };
     let value = value.take_inner();
-    let keyspace_tag = match KeyspaceTag::from_u64(key_space) {
-        Some(keyspace_tag) => keyspace_tag,
-        None => {
-            // Unknown keyspace received, return error
-            return Ok(HOST_ERROR_INVALID_INPUT);
-        }
-    };
-
-    let keyspace = match keyspace_tag {
-        KeyspaceTag::Context => {
-            let ctx_addr: ContextAddr = match borsh::from_slice(&key_payload_bytes) {
-                Ok(v) => v,
-                Err(_) => return Ok(HOST_ERROR_INVALID_INPUT),
-            };
-            Keyspace::Context(ctx_addr)
-        }
-        KeyspaceTag::NamedKey => {
-            let key_name = match std::str::from_utf8(&key_payload_bytes) {
-                Ok(key_name) => key_name,
-                Err(_) => {
-                    return Ok(HOST_ERROR_INVALID_INPUT);
-                }
-            };
-            Keyspace::NamedKey(key_name)
-        }
-        KeyspaceTag::TypeDef => match <[u8; 4]>::try_from(key_payload_bytes.as_slice()) {
-            Ok(array) => {
-                let u32_value = u32::from_le_bytes(array);
-                let uid = Uid::new_raw(u32_value);
-                Keyspace::TypeDef(uid)
-            }
-            Err(_) => {
-                error!("Invalid TypeDef Uid bytes length");
-                return Ok(HOST_ERROR_INVALID_DATA);
-            }
-        },
-        KeyspaceTag::EntryPoint => Keyspace::EntryPoint(
-            std::str::from_utf8(&key_payload_bytes).map_err(|_| FatalHostError::TypeConversion)?,
-        ),
+    let keyspace = match deserialize_keyspace(raw_keyspace_tag, &key_payload_bytes) {
+        Ok(keyspace) => keyspace,
+        Err(err_code) => return Ok(err_code),
     };
 
     let global_state_key = match keyspace_to_global_state_key(caller.context(), keyspace.clone()) {
@@ -273,7 +228,7 @@ pub(crate) fn host_write<S: GlobalStateReader + 'static>(
             let cl_value_any = CLValue::from_components(CLType::Any, value);
             StoredValue::CLValue(cl_value_any)
         }
-        Keyspace::NamedKey(name) => {
+        Keyspace::NamedValue(name) => {
             // NamedKey points to a URef which holds CLValue::Any bytes
             let maybe_stored_value = caller
                 .context_mut()
@@ -325,6 +280,29 @@ pub(crate) fn host_write<S: GlobalStateReader + 'static>(
 
                     StoredValue::Contract(contract)
                 }
+                Some(StoredValue::Account(mut account)) => {
+                    let uref = match account.named_keys().get(name) {
+                        Some(Key::URef(uref)) => *uref,
+                        Some(_) => return Ok(HOST_ERROR_INVALID_INPUT),
+                        None => {
+                            let mut address_generator = caller.context().address_generator.write();
+                            address_generator.new_uref(AccessRights::NONE)
+                        }
+                    };
+
+                    // Write payload bytes under the URef as CLValue::Any
+                    let cl_value_any = CLValue::from_components(CLType::Any, value.clone());
+                    metered_write(caller, Key::URef(uref), StoredValue::CLValue(cl_value_any))?;
+
+                    let named_keys = {
+                        let mut ret = BTreeMap::new();
+                        ret.insert(name.to_string(), Key::URef(uref));
+                        NamedKeys::from(ret)
+                    };
+                    account.named_keys_append(named_keys);
+
+                    StoredValue::Account(account)
+                }
                 Some(_) => return Ok(HOST_ERROR_NOT_FOUND),
                 None => {
                     let uref = {
@@ -359,6 +337,52 @@ pub(crate) fn host_write<S: GlobalStateReader + 'static>(
     Ok(HOST_ERROR_SUCCESS)
 }
 
+fn deserialize_keyspace(
+    raw_keyspace_tag: u64,
+    key_payload_bytes: &BytesreprBytes,
+) -> Result<Keyspace<'_>, u32> {
+    let keyspace_tag = match KeyspaceTag::from_u64(raw_keyspace_tag) {
+        Some(keyspace_tag) => keyspace_tag,
+        None => {
+            // Unknown keyspace received, return error
+            return Err(HOST_ERROR_INVALID_INPUT);
+        }
+    };
+    let keyspace = match keyspace_tag {
+        KeyspaceTag::Context => {
+            let ctx_addr: ContextAddr = match borsh::from_slice(key_payload_bytes) {
+                Ok(v) => v,
+                Err(_) => return Err(HOST_ERROR_INVALID_INPUT),
+            };
+            Keyspace::Context(ctx_addr)
+        }
+        KeyspaceTag::NamedKey => {
+            let key_name = match std::str::from_utf8(key_payload_bytes) {
+                Ok(key_name) => key_name,
+                Err(_) => {
+                    return Err(HOST_ERROR_INVALID_INPUT);
+                }
+            };
+            Keyspace::NamedValue(key_name)
+        }
+        KeyspaceTag::TypeDef => match <[u8; 4]>::try_from(key_payload_bytes.as_slice()) {
+            Ok(array) => {
+                let u32_value = u32::from_le_bytes(array);
+                let uid = Uid::new_raw(u32_value);
+                Keyspace::TypeDef(uid)
+            }
+            Err(_) => {
+                error!("Invalid TypeDef Uid bytes length");
+                return Err(HOST_ERROR_INVALID_DATA);
+            }
+        },
+        KeyspaceTag::EntryPoint => Keyspace::EntryPoint(
+            std::str::from_utf8(key_payload_bytes).map_err(|_| HOST_ERROR_INVALID_DATA)?,
+        ),
+    };
+    Ok(keyspace)
+}
+
 /// Remove value under a key.
 ///
 /// This produces a transformation of Prune to the global state. Keep in mind that technically the
@@ -371,55 +395,21 @@ pub(crate) fn host_remove<S: GlobalStateReader + 'static>(
     caller: &mut impl Caller<Context = Context<S>>,
     input: Bytes,
 ) -> VMResult<u32> {
-    let (key_space, key_payload_bytes) =
+    let (raw_keyspace_tag, key_payload_bytes) =
         match bytesrepr::deserialize_from_slice::<&Bytes, (u64, BytesreprBytes)>(&input) {
             Ok(res) => res,
             Err(_) => {
                 return Ok(HOST_ERROR_INVALID_INPUT);
             }
         };
-
-    let keyspace_tag = match KeyspaceTag::from_u64(key_space) {
-        Some(keyspace_tag) => keyspace_tag,
-        None => {
-            // Unknown keyspace received, return error
-            return Ok(HOST_ERROR_NOT_FOUND);
-        }
+    let keyspace = match deserialize_keyspace(raw_keyspace_tag, &key_payload_bytes) {
+        Ok(keyspace) => keyspace,
+        Err(err_code) => return Ok(err_code),
     };
 
-    let keyspace = match keyspace_tag {
-        KeyspaceTag::Context => {
-            let ctx_addr: ContextAddr = match borsh::from_slice(&key_payload_bytes) {
-                Ok(v) => v,
-                Err(_) => return Ok(HOST_ERROR_INVALID_INPUT),
-            };
-            Keyspace::Context(ctx_addr)
-        }
-        KeyspaceTag::NamedKey => {
-            let key_name = match std::str::from_utf8(&key_payload_bytes) {
-                Ok(key_name) => key_name,
-                Err(_) => {
-                    return Ok(HOST_ERROR_INVALID_DATA);
-                }
-            };
-            Keyspace::NamedKey(key_name)
-        }
-        KeyspaceTag::TypeDef => {
-            let u32_value = if key_payload_bytes.len() != 4 {
-                error!("Invalid TypeDef Uid bytes length");
-                return Ok(HOST_ERROR_INVALID_DATA);
-            } else {
-                let mut array = [0u8; 4];
-                array.copy_from_slice(&key_payload_bytes[..4]);
-                u32::from_le_bytes(array)
-            };
-            let uid = Uid::new_raw(u32_value);
-            Keyspace::TypeDef(uid)
-        }
-        KeyspaceTag::EntryPoint => Keyspace::EntryPoint(
-            std::str::from_utf8(&key_payload_bytes).map_err(|_| FatalHostError::TypeConversion)?,
-        ),
-    };
+    if let Keyspace::NamedValue(_) = keyspace {
+        return Ok(HOST_ERROR_INVALID_INPUT);
+    }
 
     let global_state_key = match keyspace_to_global_state_key(caller.context(), keyspace.clone()) {
         Some(global_state_key) => global_state_key,
@@ -432,9 +422,29 @@ pub(crate) fn host_remove<S: GlobalStateReader + 'static>(
     let global_state_read_result = caller.context_mut().tracking_copy.read(&global_state_key);
     match global_state_read_result {
         Ok(Some(StoredValue::AddressableEntity(_))) => return Ok(HOST_ERROR_INVALID_INPUT),
+        Ok(Some(StoredValue::Account(mut account))) => match keyspace {
+            Keyspace::NamedValue(name) => {
+                account.named_keys_mut().remove(name);
+                metered_write(caller, global_state_key, StoredValue::Account(account))?;
+            }
+            _ => {
+                error!(?keyspace, "unsupported keyspace");
+                return Ok(HOST_ERROR_INVALID_INPUT);
+            }
+        },
+        Ok(Some(StoredValue::Contract(mut contract))) => match keyspace {
+            Keyspace::NamedValue(name) => {
+                contract.remove_named_key(name);
+                metered_write(caller, global_state_key, StoredValue::Contract(contract))?;
+            }
+            _ => {
+                error!(?keyspace, "unsupported keyspace");
+                return Ok(HOST_ERROR_INVALID_INPUT);
+            }
+        },
         Ok(Some(_)) => {
             // If it's a named key pointing to a URef, prune both the named key and the URef.
-            if matches!(keyspace, Keyspace::NamedKey(_)) {
+            if matches!(keyspace, Keyspace::NamedValue(_)) {
                 if let Ok(Some(StoredValue::NamedKey(named_key_value))) =
                     caller.context_mut().tracking_copy.read(&global_state_key)
                 {
@@ -1010,6 +1020,100 @@ pub(crate) fn host_create<S: GlobalStateReader + 'static>(
     // Ok((Some(create_result_bytes.into()), CALLEE_SUCCEEDED))
 }
 
+pub(crate) fn host_store_package_under_key<S: GlobalStateReader + 'static>(
+    caller: &mut impl Caller<Context = Context<S>>,
+    input: Bytes,
+) -> VMResult<u32> {
+    let package_key = caller.context().callee;
+    match package_key {
+        Key::Hash(_) | Key::AddressableEntity(EntityAddr::Package(_)) => (),
+        _ => {
+            // Storing package hash makes sense only if the called thing is a contract package
+            return Ok(HOST_ERROR_INVALID_INPUT);
+        }
+    }
+    let named_key = match bytesrepr::deserialize_from_slice::<_, String>(&input) {
+        Ok(res) => res,
+        Err(_) => {
+            return Ok(HOST_ERROR_INVALID_INPUT);
+        }
+    };
+
+    let caller_key = caller.context().caller;
+    let global_state_key = match &caller_key {
+        Key::Account(_) => caller_key,
+        Key::Hash(_) => caller_key,
+        Key::AddressableEntity(entity_addr) => {
+            let digest = Digest::hash(named_key.as_bytes());
+            Key::NamedKey(NamedKeyAddr::new_named_key_entry(
+                *entity_addr,
+                digest.value(),
+            ))
+        }
+        _ => {
+            // This should never happen, as the caller is always an account or a smart contract.
+            panic!("Unexpected callee variant: {:?}", caller_key)
+        }
+    };
+    let global_state_read_result = caller.context_mut().tracking_copy.read(&global_state_key);
+    let mut keys_to_prune = vec![];
+    let stored_value = match global_state_read_result {
+        Ok(None) => {
+            let key_name = named_key.to_string();
+            let Ok(named_key_value) = NamedKeyValue::from_concrete_values(caller_key, key_name)
+            else {
+                return Ok(HOST_ERROR_INVALID_DATA);
+            };
+            StoredValue::NamedKey(named_key_value)
+        }
+        Ok(Some(StoredValue::NamedKey(_named_key_value))) => {
+            keys_to_prune.push(global_state_key);
+            let key_name = named_key.to_string();
+            let Ok(named_key_value) = NamedKeyValue::from_concrete_values(caller_key, key_name)
+            else {
+                return Ok(HOST_ERROR_INVALID_DATA);
+            };
+            StoredValue::NamedKey(named_key_value)
+        }
+        Ok(Some(StoredValue::Account(mut account))) => {
+            let named_keys = {
+                let mut ret = BTreeMap::new();
+                ret.insert(named_key.to_string(), package_key);
+                NamedKeys::from(ret)
+            };
+            account.named_keys_append(named_keys);
+
+            StoredValue::Account(account)
+        }
+        Ok(Some(StoredValue::Contract(mut contract))) => {
+            let named_keys = {
+                let mut ret = BTreeMap::new();
+                ret.insert(named_key.to_string(), package_key);
+                NamedKeys::from(ret)
+            };
+            contract.named_keys_append(named_keys);
+
+            StoredValue::Contract(contract)
+        }
+        Err(error) => {
+            // To protect the network against potential non-determinism (i.e. one validator runs
+            // out of space or just faces I/O issues that other validators may
+            // not have) we're simply aborting the process, hoping that once the
+            // node goes back online issues are resolved on the validator side.
+            // TODO: We should signal this to the contract runtime somehow, and
+            // let validator nodes skip execution.
+            error!(?error, "Error while reading from storage; aborting");
+            panic!("Error while reading from storage; aborting key={global_state_key:?} error={error:?}")
+        }
+        _ => {
+            //Unsupported key?
+            return Ok(HOST_ERROR_INVALID_INPUT);
+        }
+    };
+    metered_write(caller, global_state_key, stored_value)?;
+    Ok(HOST_ERROR_SUCCESS)
+}
+
 fn keyspace_to_global_state_key<S: GlobalStateReader>(
     context: &Context<S>,
     keyspace: Keyspace<'_>,
@@ -1041,12 +1145,16 @@ fn keyspace_to_global_state_key<S: GlobalStateReader>(
                 )))
             }
         },
-        Keyspace::NamedKey(payload) => {
-            let digest = Digest::hash(payload.as_bytes());
-            Some(Key::NamedKey(NamedKeyAddr::new_named_key_entry(
-                entity_addr,
-                digest.value(),
-            )))
+        Keyspace::NamedValue(payload) => {
+            if context.tracking_copy.addressable_entity_enabled() {
+                let digest = Digest::hash(payload.as_bytes());
+                Some(Key::NamedKey(NamedKeyAddr::new_named_key_entry(
+                    entity_addr,
+                    digest.value(),
+                )))
+            } else {
+                Some(context.callee)
+            }
         }
         Keyspace::TypeDef(typedef) => {
             let digest = typedef.into_raw();

--- a/executor/wasm_interface/src/executor.rs
+++ b/executor/wasm_interface/src/executor.rs
@@ -411,6 +411,7 @@ pub enum GlobalStateMethods {
     GetBalance,
     GetInfo,
     Create,
+    StorePackageUnderKey,
 }
 
 /// Available options for interacting with functions interacting
@@ -504,6 +505,12 @@ impl From<FFIMenu> for u32 {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackagePointer {
+    HashAddr(HashAddr),
+    NamedKeyName(String),
+}
+
 /// Target for Wasm execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecutionKind {
@@ -511,10 +518,15 @@ pub enum ExecutionKind {
     SessionBytes(Bytes),
     /// Execute a stored contract by its address.
     Stored {
-        /// Address of the contract's package.
-        address: HashAddr,
+        /// Either Address of the contract's package or name of the NamedKey which holds the
+        /// package key.
+        package_pointer: PackagePointer,
         /// Entry point to call.
         entry_point: String,
+        /// version of the contract, `latest matching` if None
+        version: Option<u32>,
+        /// version of the protocol version, `latest matching` if None
+        protocol_version_major: Option<u32>,
     },
     /// Interact with the system.
     System(SystemContractMenu),
@@ -629,6 +641,7 @@ enum FFIPrimitiveValue {
     GlobalStateGetBalance = 403,
     GlobalStateGetInfo = 404,
     GlobalStateCreate = 405,
+    GlobalStateStorePackageUnderKey = 406,
     /* Control values */
     ControlCall = 500,
     ControlUpgrade = 501,
@@ -680,6 +693,9 @@ impl From<&FFIPrimitiveValue> for FFIMenu {
             }
             FFIPrimitiveValue::GlobalStateGetInfo => Self::GlobalState(GlobalStateMethods::GetInfo),
             FFIPrimitiveValue::GlobalStateCreate => Self::GlobalState(GlobalStateMethods::Create),
+            FFIPrimitiveValue::GlobalStateStorePackageUnderKey => {
+                Self::GlobalState(GlobalStateMethods::StorePackageUnderKey)
+            }
             FFIPrimitiveValue::ControlCall => Self::Control(ControlMethods::Call),
             FFIPrimitiveValue::ControlUpgrade => Self::Control(ControlMethods::Upgrade),
             FFIPrimitiveValue::IOReturn => Self::IO(IOMethods::Return),
@@ -726,6 +742,7 @@ impl From<&FFIMenu> for FFIPrimitiveValue {
                 GlobalStateMethods::GetBalance => Self::GlobalStateGetBalance,
                 GlobalStateMethods::GetInfo => Self::GlobalStateGetInfo,
                 GlobalStateMethods::Create => Self::GlobalStateCreate,
+                GlobalStateMethods::StorePackageUnderKey => Self::GlobalStateStorePackageUnderKey,
             },
             FFIMenu::Control(control_methods) => match control_methods {
                 ControlMethods::Call => Self::ControlCall,

--- a/executor/wasmer_backend/Cargo.toml
+++ b/executor/wasmer_backend/Cargo.toml
@@ -20,9 +20,10 @@ regex = "1.11"
 wasmer = { version = "5.0.4", default-features = false, features = [
     "singlepass",
 ] }
-wasmer-compiler-singlepass = "5.0.4"
+rkyv = "0.8.13" # defining this dependency directly due to RUSTSEC-2026-0001 coming from wasmer-types and wasmer-compiler-singlepass
+wasmer-compiler-singlepass = "5.0.6"
 wasmer-middlewares = "5.0.4"
-wasmer-types = "5.0.4"
+wasmer-types = "5.0.6"
 tracing = "0.1.41"
 
 [dev-dependencies]

--- a/node/src/components/contract_runtime/operations/wasm_v2_request.rs
+++ b/node/src/components/contract_runtime/operations/wasm_v2_request.rs
@@ -7,7 +7,7 @@ use casper_executor_wasm_common::error::CallError;
 use casper_executor_wasm_interface::{
     executor::{
         ExecuteError, ExecuteRequest, ExecuteRequestBuilder, ExecuteWithProviderError,
-        ExecuteWithProviderResult, ExecutionKind,
+        ExecuteWithProviderResult, ExecutionKind, PackagePointer,
     },
     install::{
         InstallContractError, InstallContractRequest, InstallContractRequestBuilder,
@@ -148,7 +148,7 @@ pub(crate) enum InvalidRequest {
     ExpectedTransferredValue,
     #[error("Expected V2 runtime")]
     ExpectedV2Runtime,
-    #[error("Invalida input")]
+    #[error("Invalid input")]
     InvalidaInput,
 }
 
@@ -382,8 +382,38 @@ impl WasmV2Request {
                         id: TransactionInvocationTarget::ByHash(smart_contract_addr),
                         entry_point,
                     } => ExecutionKind::Stored {
-                        address: smart_contract_addr,
+                        package_pointer: PackagePointer::HashAddr(smart_contract_addr),
                         entry_point: entry_point.clone(),
+                        version: None,
+                        protocol_version_major: None,
+                    },
+                    Target::Stored {
+                        id:
+                            TransactionInvocationTarget::ByPackageHash {
+                                addr,
+                                version,
+                                protocol_version_major,
+                            },
+                        entry_point,
+                    } => ExecutionKind::Stored {
+                        package_pointer: PackagePointer::HashAddr(addr.value()),
+                        entry_point: entry_point.clone(),
+                        version,
+                        protocol_version_major,
+                    },
+                    Target::Stored {
+                        id:
+                            TransactionInvocationTarget::ByPackageName {
+                                name,
+                                version,
+                                protocol_version_major,
+                            },
+                        entry_point,
+                    } => ExecutionKind::Stored {
+                        package_pointer: PackagePointer::NamedKeyName(name),
+                        entry_point: entry_point.clone(),
+                        version,
+                        protocol_version_major,
                     },
                     Target::Stored { id, entry_point } => {
                         todo!("Unsupported target {entry_point} {id:?}")

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -892,7 +892,8 @@ impl TestScenario {
                     | TestScenario::FromClientRepeatedValidTransaction(_)
                     | TestScenario::FromClientValidTransaction(_)
                     | TestScenario::FromClientSlightlyFutureDatedTransaction(_)
-                    | TestScenario::FromClientSignedByAdmin(..) => true,
+                    | TestScenario::FromClientSignedByAdmin(..)
+                    | TestScenario::VmCasperV2ByPackageHash => true,
             TestScenario::FromPeerInvalidTransaction(_)
                     | TestScenario::FromPeerInvalidTransactionZeroPayment(_)
                     | TestScenario::FromClientInsufficientBalance(_)
@@ -944,8 +945,7 @@ impl TestScenario {
                     | TestScenario::WasmTransactionWithTooBigPayment
                     | TestScenario::WasmDeployWithTooBigPayment
                     | TestScenario::RedelegateExceedingMaximumDelegation { .. }
-                    | TestScenario::DelegateExceedingMaximumDelegation { .. }
-                    | TestScenario::VmCasperV2ByPackageHash => false,
+                    | TestScenario::DelegateExceedingMaximumDelegation { .. } => false,
             TestScenario::V1ByPackage(hash_or_name, _, _, scenario, ..) => {
                 match hash_or_name {
                     HashOrName::Hash => match scenario {
@@ -1583,8 +1583,7 @@ async fn run_transaction_acceptor_without_timeout(
             | TestScenario::WasmTransactionWithTooBigPayment
             | TestScenario::WasmDeployWithTooBigPayment
             | TestScenario::RedelegateExceedingMaximumDelegation { .. }
-            | TestScenario::DelegateExceedingMaximumDelegation { .. }
-            | TestScenario::VmCasperV2ByPackageHash => {
+            | TestScenario::DelegateExceedingMaximumDelegation { .. } => {
                 matches!(
                     event,
                     Event::TransactionAcceptorAnnouncement(
@@ -1688,7 +1687,8 @@ async fn run_transaction_acceptor_without_timeout(
             // `AcceptedNewTransaction` announcement with the appropriate source.
             TestScenario::FromClientValidTransaction(_)
             | TestScenario::FromClientSlightlyFutureDatedTransaction(_)
-            | TestScenario::FromClientSignedByAdmin(_) => {
+            | TestScenario::FromClientSignedByAdmin(_)
+            | TestScenario::VmCasperV2ByPackageHash => {
                 matches!(
                     event,
                     Event::TransactionAcceptorAnnouncement(
@@ -2977,17 +2977,9 @@ async fn should_reject_native_redelegate_with_exceeding_amount() {
 }
 
 #[tokio::test]
-async fn foobar() {
+async fn should_accept_vm2_call_by_package_hash() {
     let result = run_transaction_acceptor(TestScenario::VmCasperV2ByPackageHash).await;
-    assert!(
-        matches!(
-            result,
-            Err(super::Error::InvalidTransaction(InvalidTransaction::V1(
-                InvalidTransactionV1::UnsupportedInvocationTarget { id: Some(_) }
-            )))
-        ),
-        "{result:?}"
-    );
+    assert!(result.is_ok(), "{result:?}");
 }
 
 #[tokio::test]

--- a/node/src/reactor/main_reactor/tests/configs_override.rs
+++ b/node/src/reactor/main_reactor/tests/configs_override.rs
@@ -136,6 +136,11 @@ impl ConfigsOverride {
         self.node_config_override = config;
         self
     }
+
+    pub(crate) fn with_vm_casper_v2(mut self, vm_casper_v2: bool) -> Self {
+        self.vm_casper_v2 = vm_casper_v2;
+        self
+    }
 }
 
 impl Default for ConfigsOverride {

--- a/node/src/reactor/main_reactor/tests/gas_price.rs
+++ b/node/src/reactor/main_reactor/tests/gas_price.rs
@@ -51,7 +51,9 @@ async fn run_gas_price_scenario(gas_price_scenario: GasPriceScenario) {
     let spec_override = match gas_price_scenario {
         GasPriceScenario::SlotUtilization => {
             let mut transaction_config = TransactionV1Config::default();
-            transaction_config.native_mint_lane.max_transaction_count = 1;
+            transaction_config
+                .native_mint_lane
+                .set_max_transaction_count(1);
             ConfigsOverride::default().with_transaction_v1_config(transaction_config)
         }
         GasPriceScenario::SizeUtilization(block_size) => {
@@ -244,7 +246,9 @@ async fn gas_price_calc_should_not_stall_network() {
     let minimum_era_height = 5;
 
     let mut transaction_config = TransactionV1Config::default();
-    transaction_config.native_mint_lane.max_transaction_count = 1;
+    transaction_config
+        .native_mint_lane
+        .set_max_transaction_count(1);
 
     let spec_override = ConfigsOverride::default()
         .with_transaction_v1_config(transaction_config)

--- a/node/src/reactor/main_reactor/tests/transaction_scenario.rs
+++ b/node/src/reactor/main_reactor/tests/transaction_scenario.rs
@@ -1,19 +1,24 @@
 mod asertions;
 mod utils;
+
 use asertions::{
     ExecResultCost, PublicKeyBalanceChange, PublicKeyTotalMeetsAvailable, TotalSupplyChange,
     TransactionFailure, TransactionSuccessful,
 };
 use casper_types::{
-    testing::TestRng, FeeHandling, Gas, PricingMode, PublicKey, RefundHandling, TimeDiff,
-    Transaction, U512,
+    bytesrepr::{Bytes, ToBytes},
+    execution::{RetValue, TransformKindV2},
+    testing::TestRng,
+    EntityAddr, ExecutionInfo, FeeHandling, Gas, Key, PricingHandling, PricingMode, PublicKey,
+    RefundHandling, StoredValue, TimeDiff, Transaction, TransactionEntryPoint,
+    TransactionInvocationTarget, TransactionRuntimeParams, TransactionV1Config, U512,
 };
 use num_rational::Ratio;
 use utils::{build_wasm_transction, RunUntilCondition, TestScenarioBuilder};
 
 use crate::{
     reactor::main_reactor::tests::{
-        transaction_scenario::asertions::BalanceChange,
+        transaction_scenario::asertions::{BalanceChange, ExecutionResultHasRet},
         transactions::{
             invalid_wasm_txn, ALICE_PUBLIC_KEY, ALICE_SECRET_KEY, BOB_PUBLIC_KEY, BOB_SECRET_KEY,
             CHARLIE_PUBLIC_KEY, MIN_GAS_PRICE,
@@ -22,6 +27,7 @@ use crate::{
     },
     testing::LARGE_WASM_LANE_ID,
     types::transaction::transaction_v1_builder::TransactionV1Builder,
+    utils::RESOURCES_PATH,
 };
 
 #[tokio::test]
@@ -318,4 +324,567 @@ async fn should_not_refund_erroneous_wasm_burn_fixed() {
             gas_limit_y,
         ))
         .await;
+}
+
+#[tokio::test]
+async fn vm2_contract_can_be_called_using_by_package_hash() {
+    let module_bytes = read_wasm("vm2_upgradable.wasm");
+    let mut rng = TestRng::new();
+    let builder = TestScenarioBuilder::new().with_enable_vm2(true);
+
+    let mut test_scenario = builder.build(&mut rng).await;
+    let chain_name = test_scenario.chain_name();
+    test_scenario.setup().await.unwrap();
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_session(
+            true,
+            module_bytes.into(),
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_entry_point(TransactionEntryPoint::Custom("new".to_string()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(
+            10_u8.to_bytes().unwrap().into(),
+        ))
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_pricing_mode(PricingMode::Fixed {
+            gas_price_tolerance: 1,
+            additional_computation_factor: 0,
+        })
+        .with_chain_name(chain_name.clone())
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    let execution_infos = test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario.assert(TransactionSuccessful::new(hash)).await;
+    let package_hash = peel_package_hash_info(execution_infos);
+
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_targeting_stored(
+            TransactionInvocationTarget::ByHash(package_hash),
+            "get",
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(vec![].into()))
+        .with_pricing_mode(PricingMode::Fixed {
+            gas_price_tolerance: 1,
+            additional_computation_factor: 0,
+        })
+        .with_chain_name(chain_name)
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario.assert(TransactionSuccessful::new(hash)).await;
+    test_scenario
+        .assert(ExecutionResultHasRet::new(
+            hash,
+            RetValue::Bytes(10_u8.to_bytes().unwrap().into()),
+        ))
+        .await;
+}
+
+#[tokio::test]
+async fn vm2_contract_can_be_called_using_by_package_hash_with_version() {
+    let module_bytes = read_wasm("vm2_upgradable.wasm");
+    let mut rng = TestRng::new();
+    let builder = TestScenarioBuilder::new().with_enable_vm2(true);
+
+    let mut test_scenario = builder.build(&mut rng).await;
+    let chain_name = test_scenario.chain_name();
+    test_scenario.setup().await.unwrap();
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_session(
+            true,
+            module_bytes.into(),
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_entry_point(TransactionEntryPoint::Custom("new".to_string()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(
+            10_u8.to_bytes().unwrap().into(),
+        ))
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_pricing_mode(PricingMode::Fixed {
+            gas_price_tolerance: 1,
+            additional_computation_factor: 0,
+        })
+        .with_chain_name(chain_name.clone())
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    let execution_infos = test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario.assert(TransactionSuccessful::new(hash)).await;
+    let package_hash = peel_package_hash_info(execution_infos);
+
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_targeting_stored(
+            TransactionInvocationTarget::ByPackageHash {
+                addr: package_hash.into(),
+                version: Some(1),
+                protocol_version_major: Some(test_scenario.get_protocol_version().destructure().0),
+            },
+            "get",
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(vec![].into()))
+        .with_pricing_mode(PricingMode::Fixed {
+            gas_price_tolerance: 1,
+            additional_computation_factor: 0,
+        })
+        .with_chain_name(chain_name)
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario.assert(TransactionSuccessful::new(hash)).await;
+    test_scenario
+        .assert(ExecutionResultHasRet::new(
+            hash,
+            RetValue::Bytes(10_u8.to_bytes().unwrap().into()),
+        ))
+        .await;
+}
+
+#[tokio::test]
+async fn vm2_contract_calling_by_hash_nonexistent_fails() {
+    let module_bytes = read_wasm("vm2_upgradable.wasm");
+    let mut rng = TestRng::new();
+    let builder = TestScenarioBuilder::new().with_enable_vm2(true);
+
+    let mut test_scenario = builder.build(&mut rng).await;
+    let chain_name = test_scenario.chain_name();
+    test_scenario.setup().await.unwrap();
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_session(
+            true,
+            module_bytes.into(),
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_entry_point(TransactionEntryPoint::Custom("new".to_string()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(
+            10_u8.to_bytes().unwrap().into(),
+        ))
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_pricing_mode(PricingMode::Fixed {
+            gas_price_tolerance: 1,
+            additional_computation_factor: 0,
+        })
+        .with_chain_name(chain_name.clone())
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    let execution_infos = test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario.assert(TransactionSuccessful::new(hash)).await;
+    let package_hash = peel_package_hash_info(execution_infos);
+
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_targeting_stored(
+            TransactionInvocationTarget::ByPackageHash {
+                addr: package_hash.into(),
+                version: Some(100), //Nonexistent version
+                protocol_version_major: Some(test_scenario.get_protocol_version().destructure().0),
+            },
+            "get",
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(vec![].into()))
+        .with_pricing_mode(PricingMode::Fixed {
+            gas_price_tolerance: 1,
+            additional_computation_factor: 0,
+        })
+        .with_chain_name(chain_name)
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario
+        .assert(TransactionFailure::expected_error_message(
+            hash,
+            "no active contract",
+        ))
+        .await;
+}
+
+#[tokio::test]
+async fn vm2_contract_calling_by_hash_after_upgrade() {
+    let module_bytes = read_wasm("vm2_upgradable.wasm");
+    let mut rng = TestRng::new();
+    let mut test_scenario = TestScenarioBuilder::new()
+        .with_pricing_handling(PricingHandling::PaymentLimited)
+        .with_enable_vm2(true)
+        .with_transaction_v1_config(TransactionV1Config::very_big_wasm_lane())
+        .build(&mut rng)
+        .await;
+    let chain_name = test_scenario.chain_name();
+    test_scenario.setup().await.unwrap();
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_session(
+            true,
+            module_bytes.into(),
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_entry_point(TransactionEntryPoint::Custom("new".to_string()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(
+            0_u8.to_bytes().unwrap().into(),
+        ))
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_pricing_mode(PricingMode::PaymentLimited {
+            payment_amount: 100_000_000_000_u64,
+            gas_price_tolerance: 1,
+            standard_payment: true,
+        })
+        .with_chain_name(chain_name.clone())
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    let execution_infos = test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario.assert(TransactionSuccessful::new(hash)).await;
+    let package_hash = peel_package_hash_info(execution_infos);
+
+    let new_code = Bytes::from(read_wasm("vm2_upgradable_v2.wasm"));
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_targeting_stored(
+            TransactionInvocationTarget::ByPackageHash {
+                addr: package_hash.into(),
+                version: None,
+                protocol_version_major: None,
+            },
+            "perform_upgrade",
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(
+            new_code.to_bytes().unwrap().into(),
+        ))
+        .with_pricing_mode(PricingMode::PaymentLimited {
+            payment_amount: 100_000_000_000_u64,
+            gas_price_tolerance: 1,
+            standard_payment: true,
+        })
+        .with_chain_name(chain_name.clone())
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario.assert(TransactionSuccessful::new(hash)).await;
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_targeting_stored(
+            TransactionInvocationTarget::ByPackageHash {
+                addr: package_hash.into(),
+                version: Some(2), //Existing version
+                protocol_version_major: Some(test_scenario.get_protocol_version().destructure().0),
+            },
+            "version",
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(vec![].into()))
+        .with_pricing_mode(PricingMode::PaymentLimited {
+            payment_amount: 100_000_000_000_u64,
+            gas_price_tolerance: 1,
+            standard_payment: true,
+        })
+        .with_chain_name(chain_name.clone())
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario.assert(TransactionSuccessful::new(hash)).await;
+    test_scenario
+        .assert(ExecutionResultHasRet::new(
+            hash,
+            RetValue::Bytes("v2".to_bytes().unwrap().into()),
+        ))
+        .await;
+
+    // The old version (1) should be disabled by the upgrade
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_targeting_stored(
+            TransactionInvocationTarget::ByPackageHash {
+                addr: package_hash.into(),
+                version: Some(1), //Existing version
+                protocol_version_major: Some(test_scenario.get_protocol_version().destructure().0),
+            },
+            "version",
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(vec![].into()))
+        .with_pricing_mode(PricingMode::PaymentLimited {
+            payment_amount: 100_000_000_000_u64,
+            gas_price_tolerance: 1,
+            standard_payment: true,
+        })
+        .with_chain_name(chain_name)
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario
+        .assert(TransactionFailure::expected_error_message(
+            hash,
+            "no active contract",
+        ))
+        .await;
+}
+
+#[tokio::test]
+async fn vm2_contract_calling_by_name_after_upgrade() {
+    let module_bytes = read_wasm("vm2_upgradable_storing_package.wasm");
+    let mut rng = TestRng::new();
+    let mut test_scenario = TestScenarioBuilder::new()
+        .with_pricing_handling(PricingHandling::PaymentLimited)
+        .with_enable_vm2(true)
+        .with_transaction_v1_config(TransactionV1Config::very_big_wasm_lane())
+        .build(&mut rng)
+        .await;
+    let chain_name = test_scenario.chain_name();
+    test_scenario.setup().await.unwrap();
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_session(
+            true,
+            module_bytes.into(),
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_entry_point(TransactionEntryPoint::Custom("new".to_string()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(
+            0_u8.to_bytes().unwrap().into(),
+        ))
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_pricing_mode(PricingMode::PaymentLimited {
+            payment_amount: 100_000_000_000_u64,
+            gas_price_tolerance: 1,
+            standard_payment: true,
+        })
+        .with_chain_name(chain_name.clone())
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario.assert(TransactionSuccessful::new(hash)).await;
+
+    let new_code = Bytes::from(read_wasm("vm2_upgradable_v2.wasm"));
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_targeting_stored(
+            TransactionInvocationTarget::ByPackageName {
+                name: "package".to_string(),
+                version: None,
+                protocol_version_major: None,
+            },
+            "perform_upgrade",
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(
+            new_code.to_bytes().unwrap().into(),
+        ))
+        .with_pricing_mode(PricingMode::PaymentLimited {
+            payment_amount: 100_000_000_000_u64,
+            gas_price_tolerance: 1,
+            standard_payment: true,
+        })
+        .with_chain_name(chain_name.clone())
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario.assert(TransactionSuccessful::new(hash)).await;
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_targeting_stored(
+            TransactionInvocationTarget::ByPackageName {
+                name: "package".to_string(),
+                version: Some(2), //Existing version
+                protocol_version_major: Some(test_scenario.get_protocol_version().destructure().0),
+            },
+            "version",
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(vec![].into()))
+        .with_pricing_mode(PricingMode::PaymentLimited {
+            payment_amount: 100_000_000_000_u64,
+            gas_price_tolerance: 1,
+            standard_payment: true,
+        })
+        .with_chain_name(chain_name.clone())
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario.assert(TransactionSuccessful::new(hash)).await;
+    test_scenario
+        .assert(ExecutionResultHasRet::new(
+            hash,
+            RetValue::Bytes("v2".to_bytes().unwrap().into()),
+        ))
+        .await;
+
+    // The old version (1) should be disabled by the upgrade
+    let mut txn: Transaction = Transaction::from(
+        TransactionV1Builder::new_targeting_stored(
+            TransactionInvocationTarget::ByPackageName {
+                name: "package".to_string(),
+                version: Some(1), //Existing version
+                protocol_version_major: Some(test_scenario.get_protocol_version().destructure().0),
+            },
+            "version",
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value: 0,
+                seed: None,
+                bundle_data: None,
+            },
+        )
+        .with_initiator_addr(PublicKey::from(ALICE_SECRET_KEY.as_ref()))
+        .with_transaction_args(casper_types::TransactionArgs::Bytesrepr(vec![].into()))
+        .with_pricing_mode(PricingMode::PaymentLimited {
+            payment_amount: 100_000_000_000_u64,
+            gas_price_tolerance: 1,
+            standard_payment: true,
+        })
+        .with_chain_name(chain_name)
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&ALICE_SECRET_KEY);
+    let hash = txn.hash();
+    test_scenario.run(vec![txn]).await.unwrap();
+    test_scenario
+        .assert(TransactionFailure::expected_error_message(
+            hash,
+            "no active contract",
+        ))
+        .await;
+}
+
+fn peel_package_hash_info(execution_infos: Vec<ExecutionInfo>) -> [u8; 32] {
+    let ei = execution_infos
+        .first()
+        .expect("Expecting at least one ExecutionInfo");
+    let er = ei
+        .execution_result
+        .clone()
+        .expect("Expected execution result");
+    match er {
+        casper_types::execution::ExecutionResult::V1(_) => {
+            panic!("Shouldn't happen")
+        }
+        casper_types::execution::ExecutionResult::V2(execution_result_v2) => {
+            let effects = execution_result_v2.effects;
+            let transforms = effects.transforms();
+            *transforms
+                .iter()
+                .filter_map(|el| {
+                    if matches!(
+                        el.kind(),
+                        TransformKindV2::Write(StoredValue::SmartContract(_))
+                    ) || matches!(
+                        el.kind(),
+                        TransformKindV2::Write(StoredValue::ContractPackage(_))
+                    ) {
+                        Some(match el.key() {
+                            Key::Hash(package_hash) => *package_hash,
+                            Key::AddressableEntity(EntityAddr::SmartContract(package_hash)) => {
+                                *package_hash
+                            }
+                            _ => todo!(),
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<[u8; 32]>>()
+                .first()
+                .expect("Expected to find key under which the package was stored")
+        }
+    }
+}
+
+fn read_wasm(file_name: &str) -> Vec<u8> {
+    let contract_file = RESOURCES_PATH
+        .join("..")
+        .join("target")
+        .join("wasm32-unknown-unknown")
+        .join("release")
+        .join(file_name);
+    std::fs::read(contract_file).expect("couldn't read module bytes")
 }

--- a/node/src/reactor/main_reactor/tests/transaction_scenario/asertions.rs
+++ b/node/src/reactor/main_reactor/tests/transaction_scenario/asertions.rs
@@ -3,7 +3,10 @@ use crate::reactor::main_reactor::tests::transactions::{
     assert_exec_result_cost, exec_result_is_success, BalanceAmount,
 };
 use async_trait::async_trait;
-use casper_types::{Gas, PublicKey, TransactionHash, U512};
+use casper_types::{
+    execution::{RetValue, TransformKindV2},
+    Gas, PublicKey, TransactionHash, U512,
+};
 use once_cell::sync::Lazy;
 use std::collections::BTreeMap;
 
@@ -33,11 +36,22 @@ impl Assertion for TransactionSuccessful {
 
 pub(crate) struct TransactionFailure {
     hash: TransactionHash,
+    expected_error_message: Option<String>,
 }
 
 impl TransactionFailure {
     pub(crate) fn new(hash: TransactionHash) -> Self {
-        Self { hash }
+        Self {
+            hash,
+            expected_error_message: None,
+        }
+    }
+
+    pub(crate) fn expected_error_message(hash: TransactionHash, error_message: &str) -> Self {
+        Self {
+            hash,
+            expected_error_message: Some(error_message.to_string()),
+        }
     }
 }
 
@@ -49,7 +63,16 @@ impl Assertion for TransactionFailure {
         let exec_info = current_state.exec_infos.get(&self.hash).unwrap();
         assert!(exec_info.execution_result.is_some());
         let result = exec_info.execution_result.as_ref().unwrap();
-        assert!(!exec_result_is_success(result));
+        let error_msg = match result {
+            casper_types::execution::ExecutionResult::V1(_) => todo!(),
+            casper_types::execution::ExecutionResult::V2(execution_result_v2) => {
+                execution_result_v2.error_message.clone()
+            }
+        };
+        assert!(error_msg.is_some());
+        if let Some(msg) = &self.expected_error_message {
+            assert_eq!(error_msg.unwrap(), msg.to_string());
+        }
     }
 }
 
@@ -224,5 +247,44 @@ impl Assertion for PublicKeyTotalMeetsAvailable {
         let after_total = balance.total;
         let after_available = balance.available;
         assert_eq!(after_total, after_available);
+    }
+}
+
+pub(crate) struct ExecutionResultHasRet {
+    hash: TransactionHash,
+    expected_ret_val: RetValue,
+}
+
+impl ExecutionResultHasRet {
+    pub(crate) fn new(hash: TransactionHash, expected_ret_val: RetValue) -> Self {
+        Self {
+            hash,
+            expected_ret_val,
+        }
+    }
+}
+
+#[async_trait]
+impl Assertion for ExecutionResultHasRet {
+    async fn assert(&self, snapshots_at_heights: BTreeMap<u64, TestStateSnapshot>) {
+        let current_state = snapshots_at_heights.last_key_value().unwrap().1;
+        assert!(current_state.exec_infos.contains_key(&self.hash));
+        let exec_info = current_state.exec_infos.get(&self.hash).unwrap();
+        assert!(exec_info.execution_result.is_some());
+        let result = exec_info.execution_result.as_ref().unwrap();
+        assert!(exec_result_is_success(result));
+        match result {
+            casper_types::execution::ExecutionResult::V1(_) => todo!(),
+            casper_types::execution::ExecutionResult::V2(execution_result_v2) => {
+                let maybe_last_ret = execution_result_v2.effects.transforms().iter().filter(|el|{
+                    matches!(el.kind(), TransformKindV2::Ret(v) if *v == self.expected_ret_val)
+                }).last();
+                assert!(maybe_last_ret.is_some());
+                let last = maybe_last_ret.unwrap();
+                assert!(
+                    matches!(last.kind(), TransformKindV2::Ret(v) if *v == self.expected_ret_val)
+                );
+            }
+        }
     }
 }

--- a/node/src/reactor/main_reactor/tests/transaction_scenario/utils.rs
+++ b/node/src/reactor/main_reactor/tests/transaction_scenario/utils.rs
@@ -9,8 +9,8 @@ use casper_storage::{
 };
 use casper_types::{
     account::AccountHash, bytesrepr::Bytes, testing::TestRng, EraId, ExecutionInfo, FeeHandling,
-    KeyTag, PricingHandling, PricingMode, PublicKey, RefundHandling, SecretKey, TimeDiff,
-    Transaction, TransactionHash, TransactionRuntimeParams, U512,
+    KeyTag, PricingHandling, PricingMode, ProtocolVersion, PublicKey, RefundHandling, SecretKey,
+    TimeDiff, Transaction, TransactionHash, TransactionRuntimeParams, TransactionV1Config, U512,
 };
 use once_cell::sync::OnceCell;
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
@@ -349,11 +349,15 @@ impl TestScenario {
             .transaction_config
             .transaction_v1_config
             .get_lane_by_id(lane_id)
-            .map(|el| el.max_transaction_gas_limit)
+            .map(|el| el.max_transaction_gas_limit())
     }
 
     pub(crate) fn get_block_height(&self) -> u64 {
         self.data.block_height
+    }
+
+    pub(crate) fn get_protocol_version(&self) -> ProtocolVersion {
+        self.data.fixture.chainspec.protocol_version()
     }
 }
 
@@ -368,6 +372,8 @@ pub(crate) struct TestScenarioBuilder {
     maybe_fee_handling: Option<FeeHandling>,
     maybe_balance_hold_interval_override: Option<TimeDiff>,
     maybe_minimum_era_height: Option<u64>,
+    enable_vm2: bool,
+    maybe_transaction_v1_config: Option<TransactionV1Config>,
 }
 
 impl TestScenarioBuilder {
@@ -384,6 +390,8 @@ impl TestScenarioBuilder {
             maybe_fee_handling,
             maybe_balance_hold_interval_override,
             maybe_minimum_era_height,
+            enable_vm2,
+            maybe_transaction_v1_config,
         } = self;
         let (secret_keys, stakes) = maybe_stakes_setup.unwrap_or({
             /* Node 0 is effectively guaranteed to be the proposer. */
@@ -409,7 +417,14 @@ impl TestScenarioBuilder {
                 era_id: ERA_ONE,
                 within: ONE_MIN,
             });
-        let config = ConfigsOverride::default().with_pricing_handling(pricing_handling);
+        let config = ConfigsOverride::default()
+            .with_pricing_handling(pricing_handling)
+            .with_vm_casper_v2(enable_vm2);
+        let config = if let Some(transaction_v1_config) = maybe_transaction_v1_config {
+            config.with_transaction_v1_config(transaction_v1_config)
+        } else {
+            config
+        };
         let config = if let Some(refund_handling) = maybe_refund_handling {
             config.with_refund_handling(refund_handling)
         } else {
@@ -454,6 +469,11 @@ impl TestScenarioBuilder {
         self
     }
 
+    pub fn with_pricing_handling(mut self, pricing_handling: PricingHandling) -> Self {
+        self.maybe_pricing_handling = Some(pricing_handling);
+        self
+    }
+
     pub(crate) fn with_fee_handling(mut self, fee_handling: FeeHandling) -> Self {
         self.maybe_fee_handling = Some(fee_handling);
         self
@@ -466,6 +486,19 @@ impl TestScenarioBuilder {
 
     pub(crate) fn with_minimum_era_height(mut self, minimum_era_height: u64) -> Self {
         self.maybe_minimum_era_height = Some(minimum_era_height);
+        self
+    }
+
+    pub(crate) fn with_enable_vm2(mut self, enable_vm2: bool) -> Self {
+        self.enable_vm2 = enable_vm2;
+        self
+    }
+
+    pub(crate) fn with_transaction_v1_config(
+        mut self,
+        transaction_v1_config: TransactionV1Config,
+    ) -> Self {
+        self.maybe_transaction_v1_config = Some(transaction_v1_config);
         self
     }
 }

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -5575,10 +5575,10 @@ async fn run_sizing_scenario(sizing_scenario: SizingScenario) {
     let largest_lane = wasm_lanes
         .iter()
         .max_by(|left, right| {
-            left.max_transaction_length
-                .cmp(&right.max_transaction_length)
+            left.max_transaction_length()
+                .cmp(&right.max_transaction_length())
         })
-        .map(|definition| definition.id)
+        .map(|definition| definition.id())
         .expect("must have lane id for largest lane");
 
     let (payment_2, session_2) = match sizing_scenario {
@@ -5730,17 +5730,17 @@ async fn should_assign_deploy_to_largest_lane_by_payment_amount_only_in_payment_
         .clone();
 
     wasm_lanes.sort_by(|a, b| {
-        a.max_transaction_gas_limit
-            .cmp(&b.max_transaction_gas_limit)
+        a.max_transaction_gas_limit()
+            .cmp(&b.max_transaction_gas_limit())
     });
 
     let (smallest_lane_id, smallest_gas_limt, smallest_size_limit_for_deploy) = wasm_lanes
         .first()
         .map(|lane_def| {
             (
-                lane_def.id,
-                lane_def.max_transaction_gas_limit,
-                lane_def.max_transaction_length,
+                lane_def.id(),
+                lane_def.max_transaction_gas_limit(),
+                lane_def.max_transaction_length(),
             )
         })
         .expect("must have at least one lane");
@@ -5788,7 +5788,7 @@ async fn should_assign_deploy_to_largest_lane_by_payment_amount_only_in_payment_
 
     let (largest_lane_id, largest_gas_limt) = wasm_lanes
         .last()
-        .map(|lane_def| (lane_def.id, lane_def.max_transaction_gas_limit))
+        .map(|lane_def| (lane_def.id(), lane_def.max_transaction_gas_limit()))
         .expect("must have at least one lane");
 
     assert_ne!(largest_lane_id, smallest_lane_id);

--- a/node/src/types/transaction/meta_transaction.rs
+++ b/node/src/types/transaction/meta_transaction.rs
@@ -512,20 +512,20 @@ mod proptests {
         fn construction_roundtrip(transaction in legal_transaction_arb()) {
             let mut transaction_config = TransactionConfig::default();
             transaction_config.transaction_v1_config.set_wasm_lanes(vec![
-                TransactionLaneDefinition {
-                    id: 3,
-                    max_transaction_length: u64::MAX/2,
-                    max_transaction_args_length: 10000,
-                    max_transaction_gas_limit: u64::MAX/2,
-                    max_transaction_count: 10,
-                },
-                TransactionLaneDefinition {
-                    id: 4,
-                    max_transaction_length: u64::MAX,
-                    max_transaction_args_length: 10000,
-                    max_transaction_gas_limit: u64::MAX,
-                    max_transaction_count: 10,
-                },
+                TransactionLaneDefinition::new(
+                     3,
+                     u64::MAX/2,
+                     10000,
+                     u64::MAX/2,
+                     10,
+                ),
+                TransactionLaneDefinition::new(
+                     4,
+                     u64::MAX,
+                     10000,
+                     u64::MAX,
+                     10,
+                ),
                 ]);
             let maybe_transaction = MetaTransaction::from_transaction(&transaction, PricingHandling::PaymentLimited, &transaction_config);
             prop_assert!(maybe_transaction.is_ok(), "{:?}", maybe_transaction);

--- a/node/src/types/transaction/meta_transaction/meta_deploy.rs
+++ b/node/src/types/transaction/meta_transaction/meta_deploy.rs
@@ -59,10 +59,10 @@ pub(crate) fn calculate_lane_id_of_biggest_wasm(
     wasm_lanes
         .iter()
         .max_by(|left, right| {
-            left.max_transaction_length
-                .cmp(&right.max_transaction_length)
+            left.max_transaction_length()
+                .cmp(&right.max_transaction_length())
         })
-        .map(|definition| definition.id)
+        .map(|definition| definition.id())
 }
 #[cfg(test)]
 mod tests {
@@ -77,69 +77,21 @@ mod tests {
     #[test]
     fn calculate_lane_id_of_biggest_wasm_should_return_biggest() {
         let wasms = vec![
-            TransactionLaneDefinition {
-                id: 0,
-                max_transaction_length: 1,
-                max_transaction_args_length: 2,
-                max_transaction_gas_limit: 3,
-                max_transaction_count: 4,
-            },
-            TransactionLaneDefinition {
-                id: 1,
-                max_transaction_length: 10,
-                max_transaction_args_length: 2,
-                max_transaction_gas_limit: 3,
-                max_transaction_count: 4,
-            },
+            TransactionLaneDefinition::new(0, 1, 2, 3, 4),
+            TransactionLaneDefinition::new(1, 10, 2, 3, 4),
         ];
         assert_eq!(calculate_lane_id_of_biggest_wasm(&wasms), Some(1));
         let wasms = vec![
-            TransactionLaneDefinition {
-                id: 0,
-                max_transaction_length: 1,
-                max_transaction_args_length: 2,
-                max_transaction_gas_limit: 3,
-                max_transaction_count: 4,
-            },
-            TransactionLaneDefinition {
-                id: 1,
-                max_transaction_length: 10,
-                max_transaction_args_length: 2,
-                max_transaction_gas_limit: 3,
-                max_transaction_count: 4,
-            },
-            TransactionLaneDefinition {
-                id: 2,
-                max_transaction_length: 7,
-                max_transaction_args_length: 2,
-                max_transaction_gas_limit: 3,
-                max_transaction_count: 4,
-            },
+            TransactionLaneDefinition::new(0, 1, 2, 3, 4),
+            TransactionLaneDefinition::new(1, 10, 2, 3, 4),
+            TransactionLaneDefinition::new(2, 7, 2, 3, 4),
         ];
         assert_eq!(calculate_lane_id_of_biggest_wasm(&wasms), Some(1));
 
         let wasms = vec![
-            TransactionLaneDefinition {
-                id: 0,
-                max_transaction_length: 1,
-                max_transaction_args_length: 2,
-                max_transaction_gas_limit: 3,
-                max_transaction_count: 4,
-            },
-            TransactionLaneDefinition {
-                id: 1,
-                max_transaction_length: 10,
-                max_transaction_args_length: 2,
-                max_transaction_gas_limit: 3,
-                max_transaction_count: 4,
-            },
-            TransactionLaneDefinition {
-                id: 2,
-                max_transaction_length: 70,
-                max_transaction_args_length: 2,
-                max_transaction_gas_limit: 3,
-                max_transaction_count: 4,
-            },
+            TransactionLaneDefinition::new(0, 1, 2, 3, 4),
+            TransactionLaneDefinition::new(1, 10, 2, 3, 4),
+            TransactionLaneDefinition::new(2, 70, 2, 3, 4),
         ];
         assert_eq!(calculate_lane_id_of_biggest_wasm(&wasms), Some(2));
     }

--- a/node/src/types/transaction/meta_transaction/meta_transaction_v1.rs
+++ b/node/src/types/transaction/meta_transaction/meta_transaction_v1.rs
@@ -3,10 +3,9 @@ use casper_types::{
     bytesrepr::ToBytes, calculate_transaction_lane, crypto, Approval, Chainspec,
     ContractRuntimeTag, Digest, DisplayIter, Gas, HashAddr, InitiatorAddr, InvalidTransaction,
     InvalidTransactionV1, PricingHandling, PricingMode, TimeDiff, Timestamp, TransactionArgs,
-    TransactionConfig, TransactionEntryPoint, TransactionInvocationTarget,
-    TransactionRuntimeParams, TransactionScheduling, TransactionTarget, TransactionV1,
-    TransactionV1Config, TransactionV1ExcessiveSizeError, TransactionV1Hash, AUCTION_LANE_ID,
-    MINT_LANE_ID, U512,
+    TransactionConfig, TransactionEntryPoint, TransactionRuntimeParams, TransactionScheduling,
+    TransactionTarget, TransactionV1, TransactionV1Config, TransactionV1ExcessiveSizeError,
+    TransactionV1Hash, AUCTION_LANE_ID, MINT_LANE_ID, U512,
 };
 use core::fmt::{self, Debug, Display, Formatter};
 use datasize::DataSize;
@@ -379,16 +378,6 @@ impl MetaTransactionV1 {
                     }
                     PricingMode::Fixed { .. } => {}
                     PricingMode::Prepaid { .. } => {}
-                }
-
-                if let TransactionTarget::Stored {
-                    id:
-                        id @ TransactionInvocationTarget::ByPackageHash { .. }
-                        | id @ TransactionInvocationTarget::ByPackageName { .. },
-                    runtime: _,
-                } = self.target.clone()
-                {
-                    return Err(InvalidTransactionV1::UnsupportedInvocationTarget { id: Some(id) });
                 }
             }
             None => {
@@ -928,20 +917,8 @@ mod tests {
         .unwrap();
         let mut config = TransactionV1Config::default();
         config.set_wasm_lanes(vec![
-            TransactionLaneDefinition {
-                id: 3,
-                max_transaction_length: 200,
-                max_transaction_args_length: 100,
-                max_transaction_gas_limit: 100,
-                max_transaction_count: 10,
-            },
-            TransactionLaneDefinition {
-                id: 4,
-                max_transaction_length: 500,
-                max_transaction_args_length: 100,
-                max_transaction_gas_limit: 10000,
-                max_transaction_count: 10,
-            },
+            TransactionLaneDefinition::new(3, 200, 100, 100, 10),
+            TransactionLaneDefinition::new(4, 500, 100, 10000, 10),
         ]);
 
         let res = MetaTransactionV1::from_transaction_v1(&transaction_v1, &config);
@@ -981,27 +958,9 @@ mod tests {
     fn build_v1_config() -> TransactionV1Config {
         let mut config = TransactionV1Config::default();
         config.set_wasm_lanes(vec![
-            TransactionLaneDefinition {
-                id: 3,
-                max_transaction_length: 10000,
-                max_transaction_args_length: 100,
-                max_transaction_gas_limit: 100,
-                max_transaction_count: 10,
-            },
-            TransactionLaneDefinition {
-                id: 4,
-                max_transaction_length: 10001,
-                max_transaction_args_length: 100,
-                max_transaction_gas_limit: 10000,
-                max_transaction_count: 10,
-            },
-            TransactionLaneDefinition {
-                id: 5,
-                max_transaction_length: 10002,
-                max_transaction_args_length: 100,
-                max_transaction_gas_limit: 1000,
-                max_transaction_count: 10,
-            },
+            TransactionLaneDefinition::new(3, 10000, 100, 100, 10),
+            TransactionLaneDefinition::new(4, 10001, 100, 10000, 10),
+            TransactionLaneDefinition::new(5, 10002, 100, 1000, 10),
         ]);
         config
     }

--- a/node/src/utils/chain_specification.rs
+++ b/node/src/utils/chain_specification.rs
@@ -160,11 +160,11 @@ pub(crate) fn validate_transaction_config(transaction_config: &TransactionConfig
         return false;
     }
     for wasm_lane_config in transaction_config.transaction_v1_config.wasm_lanes().iter() {
-        if RESERVED_LANE_IDS.contains(&wasm_lane_config.id) {
-            error!("One of the defined wasm lanes has declared an id that is reserved for system lanes. Offending lane id: {}", wasm_lane_config.id);
+        if RESERVED_LANE_IDS.contains(&wasm_lane_config.id()) {
+            error!("One of the defined wasm lanes has declared an id that is reserved for system lanes. Offending lane id: {}", wasm_lane_config.id());
             return false;
         }
-        let max_transaction_length = wasm_lane_config.max_transaction_length;
+        let max_transaction_length = wasm_lane_config.max_transaction_length();
         if seen_max_transaction_size.contains(&max_transaction_length) {
             error!("Found wasm lane configuration that has non-unique max_transaction_length. Duplicate value: {}", max_transaction_length);
             return false;
@@ -175,7 +175,7 @@ pub(crate) fn validate_transaction_config(transaction_config: &TransactionConfig
     let mut seen_max_gas_prices = HashSet::new();
     for wasm_lane_config in transaction_config.transaction_v1_config.wasm_lanes().iter() {
         //No need to check reserved lanes, we just did that
-        let max_transaction_gas_limit = wasm_lane_config.max_transaction_gas_limit;
+        let max_transaction_gas_limit = wasm_lane_config.max_transaction_gas_limit();
         if seen_max_gas_prices.contains(&max_transaction_gas_limit) {
             error!("Found wasm lane configuration that has non-unique max_transaction_gas_limit. Duplicate value: {}", max_transaction_gas_limit);
             return false;
@@ -732,27 +732,9 @@ mod tests {
     #[test]
     fn should_fail_when_wasm_lanes_have_duplicate_max_transaction_length() {
         let mut v1_config = TransactionV1Config::default();
-        let definition_1 = TransactionLaneDefinition {
-            id: 3,
-            max_transaction_length: 100,
-            max_transaction_args_length: 100,
-            max_transaction_gas_limit: 100,
-            max_transaction_count: 10,
-        };
-        let definition_2 = TransactionLaneDefinition {
-            id: 4,
-            max_transaction_length: 10000,
-            max_transaction_args_length: 100,
-            max_transaction_gas_limit: 101,
-            max_transaction_count: 10,
-        };
-        let definition_3 = TransactionLaneDefinition {
-            id: 5,
-            max_transaction_length: 1000,
-            max_transaction_args_length: 100,
-            max_transaction_gas_limit: 102,
-            max_transaction_count: 10,
-        };
+        let definition_1 = TransactionLaneDefinition::new(3, 100, 100, 100, 10);
+        let definition_2 = TransactionLaneDefinition::new(4, 10000, 100, 101, 10);
+        let definition_3 = TransactionLaneDefinition::new(5, 1000, 100, 102, 10);
         v1_config.set_wasm_lanes(vec![
             definition_1.clone(),
             definition_2.clone(),
@@ -764,7 +746,7 @@ mod tests {
         };
         assert!(validate_transaction_config(&transaction_config));
         let mut definition_2 = definition_2.clone();
-        definition_2.max_transaction_length = definition_1.max_transaction_length;
+        definition_2.set_max_transaction_length(definition_1.max_transaction_length());
         v1_config.set_wasm_lanes(vec![
             definition_1.clone(),
             definition_2.clone(),
@@ -780,27 +762,9 @@ mod tests {
     #[test]
     fn should_fail_when_wasm_lanes_have_duplicate_max_gas_price() {
         let mut v1_config = TransactionV1Config::default();
-        let definition_1 = TransactionLaneDefinition {
-            id: 3,
-            max_transaction_length: 100,
-            max_transaction_args_length: 100,
-            max_transaction_gas_limit: 100,
-            max_transaction_count: 10,
-        };
-        let definition_2 = TransactionLaneDefinition {
-            id: 4,
-            max_transaction_length: 10000,
-            max_transaction_args_length: 100,
-            max_transaction_gas_limit: 101,
-            max_transaction_count: 10,
-        };
-        let definition_3 = TransactionLaneDefinition {
-            id: 5,
-            max_transaction_length: 1000,
-            max_transaction_args_length: 100,
-            max_transaction_gas_limit: 102,
-            max_transaction_count: 10,
-        };
+        let definition_1 = TransactionLaneDefinition::new(3, 100, 100, 100, 10);
+        let definition_2 = TransactionLaneDefinition::new(4, 10000, 100, 101, 10);
+        let definition_3 = TransactionLaneDefinition::new(5, 1000, 100, 102, 10);
         v1_config.set_wasm_lanes(vec![
             definition_1.clone(),
             definition_2.clone(),
@@ -812,7 +776,7 @@ mod tests {
         };
         assert!(validate_transaction_config(&transaction_config));
         let mut definition_2 = definition_2.clone();
-        definition_2.max_transaction_gas_limit = definition_1.max_transaction_gas_limit;
+        definition_2.set_max_transaction_gas_limit(definition_1.max_transaction_gas_limit());
         v1_config.set_wasm_lanes(vec![
             definition_1.clone(),
             definition_2.clone(),
@@ -834,13 +798,7 @@ mod tests {
 
     fn fail_validation_with_lane_id(lane_id: u8) {
         let mut v1_config = TransactionV1Config::default();
-        let definition_1 = TransactionLaneDefinition {
-            id: lane_id,
-            max_transaction_length: 100,
-            max_transaction_args_length: 100,
-            max_transaction_gas_limit: 100,
-            max_transaction_count: 10,
-        };
+        let definition_1 = TransactionLaneDefinition::new(lane_id, 100, 100, 100, 10);
         v1_config.set_wasm_lanes(vec![definition_1.clone()]);
         let transaction_config = TransactionConfig {
             transaction_v1_config: v1_config.clone(),

--- a/smart_contracts/contracts/vm2/vm2-harness/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-harness/src/lib.rs
@@ -581,8 +581,14 @@ fn perform_test(seed: &mut Seed, flipper_address: Address) {
             &mut counter,
             "Calling non-existing entrypoint does not crash",
         );
-        let (output, result) =
-            casper::casper_call(&flipper_address, 0, "non_existing_entrypoint", &[]);
+        let (output, result) = casper::casper_call(
+            &flipper_address,
+            0,
+            "non_existing_entrypoint",
+            &[],
+            None,
+            None,
+        );
         assert_eq!(result, Err(CallError::NotCallable));
         assert_eq!(output, None);
     }

--- a/smart_contracts/contracts/vm2/vm2-host/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-host/src/lib.rs
@@ -117,17 +117,23 @@ impl MinimalHostWrapper {
     }
 
     pub fn call(&self) {
-        casper::casper_call(&[0u8; 32], 0, "", &[]).1.ok();
+        casper::casper_call(&[0u8; 32], 0, "", &[], None, None)
+            .1
+            .ok();
     }
 
     pub fn call_add_bid(&self) {
         // public key must match initiator's account hash
-        casper::casper_call(&[0u8; 32], 0, "", &[]).1.ok();
+        casper::casper_call(&[0u8; 32], 0, "", &[], None, None)
+            .1
+            .ok();
     }
 
     pub fn call_delegate(&self) {
         // should be able to send delegate from purse?
-        casper::casper_call(&[0u8; 32], 0, "", &[]).1.ok();
+        casper::casper_call(&[0u8; 32], 0, "", &[], None, None)
+            .1
+            .ok();
     }
 
     pub fn input(&self) {

--- a/smart_contracts/contracts/vm2/vm2-returner-caller/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-returner-caller/src/lib.rs
@@ -6,10 +6,10 @@ pub mod exports {
     #[casper(export)]
     pub fn call(address: Address) {
         let _ = casper::print(&format!("trying to call address {:?}", address));
-        casper::casper_call(&address, 0, "do_return", &[])
+        casper::casper_call(&address, 0, "do_return", &[], None, None)
             .1
             .unwrap();
-        casper::casper_call(&address, 0, "do_not_return", &[])
+        casper::casper_call(&address, 0, "do_not_return", &[], None, None)
             .1
             .unwrap();
     }

--- a/smart_contracts/contracts/vm2/vm2-returner-proxy/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-returner-proxy/src/lib.rs
@@ -22,7 +22,7 @@ impl ReturnerProxyContract {
             "Proxy trying to call do_return, address: {:?}",
             self.address
         ));
-        let (data, res) = casper::casper_call(&self.address, 0, "do_return", &[]);
+        let (data, res) = casper::casper_call(&self.address, 0, "do_return", &[], None, None);
         res.unwrap();
         borsh::from_slice(&data.unwrap()).unwrap()
     }
@@ -32,6 +32,6 @@ impl ReturnerProxyContract {
             "Proxy trying to call do_not_return, address: {:?}",
             self.address
         ));
-        _ = casper::casper_call(&self.address, 0, "do_not_return", &[]);
+        _ = casper::casper_call(&self.address, 0, "do_not_return", &[], None, None);
     }
 }

--- a/smart_contracts/contracts/vm2/vm2-store-named-key/Cargo.toml
+++ b/smart_contracts/contracts/vm2/vm2-store-named-key/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vm2-store-named-key"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+casper-executor-wasm-common = { path = "../../../../executor/wasm_common" }
+casper-contract-sdk = { path = "../../../vm2/sdk" }
+casper-contract-sdk-contrib = { path = "../../../vm2/sdk_contrib" }

--- a/smart_contracts/contracts/vm2/vm2-store-named-key/build.rs
+++ b/smart_contracts/contracts/vm2/vm2-store-named-key/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Check if target arch is wasm32 and set link flags accordingly
+    if std::env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
+        println!("cargo:rustc-link-arg=--import-memory");
+        println!("cargo:rustc-link-arg=--export-table");
+    }
+}

--- a/smart_contracts/contracts/vm2/vm2-store-named-key/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-store-named-key/src/lib.rs
@@ -1,0 +1,13 @@
+#![cfg_attr(target_family = "wasm", no_main)]
+
+pub mod exports {
+    use casper_contract_sdk::prelude::*;
+    use casper_executor_wasm_common::keyspace::Keyspace;
+
+    #[casper(export)]
+    pub fn call(name: String, value: Vec<u8>) {
+        casper::print(format!("Storing: {}, {:?}", name, value).as_str());
+        let key = Keyspace::NamedValue(&name);
+        casper::write(key, &value).unwrap();
+    }
+}

--- a/smart_contracts/contracts/vm2/vm2-upgradable-storing-package/Cargo.toml
+++ b/smart_contracts/contracts/vm2/vm2-upgradable-storing-package/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "vm2-upgradable-storing-package"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+casper-contract-macros = { path = "../../../vm2/macros" }
+casper-contract-sdk = { path = "../../../vm2/sdk" }
+
+[build-dependencies]
+casper-contract-sdk = { path = "../../../vm2/sdk" }

--- a/smart_contracts/contracts/vm2/vm2-upgradable-storing-package/build.rs
+++ b/smart_contracts/contracts/vm2/vm2-upgradable-storing-package/build.rs
@@ -1,0 +1,5 @@
+use casper_contract_sdk::build;
+
+fn main() {
+    build::BuildConfig::from_env().emit();
+}

--- a/smart_contracts/contracts/vm2/vm2-upgradable-storing-package/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-upgradable-storing-package/src/lib.rs
@@ -1,0 +1,78 @@
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+use casper_contract_macros::casper;
+use casper_contract_sdk::{casper, log, prelude::*};
+
+const CURRENT_VERSION: &str = "v1";
+
+/// This contract implements a simple flipper.
+#[casper(contract_state)]
+pub struct UpgradableContractStoringPackage {
+    /// The current state of the flipper.
+    value: u8,
+    /// The owner of the contract.
+    owner: Entity,
+}
+
+impl Default for UpgradableContractStoringPackage {
+    fn default() -> Self {
+        panic!("Unable to instantiate contract without a constructor");
+    }
+}
+
+// trait ContractPackage {
+//     fn versions: BTreeMap<>,
+
+// }
+
+#[casper]
+impl UpgradableContractStoringPackage {
+    #[casper(constructor)]
+    pub fn new(initial_value: u8) -> Self {
+        let caller = casper::get_caller();
+        casper::store_package_under_key("package").unwrap();
+        Self {
+            value: initial_value,
+            owner: caller,
+        }
+    }
+
+    #[casper(constructor)]
+    pub fn default() -> Self {
+        Self::new(Default::default())
+    }
+
+    pub fn increment(&mut self) {
+        self.value += 1;
+    }
+
+    pub fn get(&self) -> u8 {
+        self.value
+    }
+
+    pub fn version(&self) -> &str {
+        CURRENT_VERSION
+    }
+
+    // pub fn is_disabled(&self) {
+    //     self.disabled
+    // }
+
+    // pub fn do_something(&self) {
+    //     if self.disabled {
+    //         panic!("nope")
+
+    //     }
+    // }
+
+    #[skip_arg_parsing]
+    pub fn perform_upgrade(&self, new_code: Vec<u8>) {
+        if casper::get_caller() != self.owner {
+            panic!("Only the owner can perform upgrades");
+        }
+        log!("V1: starting upgrade process current value={}", self.value);
+        log!("New code length: {}", new_code.len());
+        log!("New code first 10 bytes: {:?}", &new_code[..10]);
+        casper::upgrade(&new_code, Some("migrate"), None).unwrap();
+    }
+}

--- a/smart_contracts/contracts/vm2/vm2-vm1-wrapper/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-vm1-wrapper/src/lib.rs
@@ -27,6 +27,8 @@ impl Vm1Wrapper {
             0,
             "counter_get",
             &EMPTY_RUNTIME_ARGS,
+            None,
+            None,
         );
         log!("counter_get_result_before: {:?}", counter_get_result_1);
         let _ = host_error.expect("No error 1");
@@ -36,6 +38,8 @@ impl Vm1Wrapper {
             0,
             "counter_inc",
             &EMPTY_RUNTIME_ARGS,
+            None,
+            None,
         );
         log!("inc_result {:?}", inc_result_1);
         assert_eq!(inc_result_1, Some(CL_VALUE_UNIT_BYTES.to_vec()));
@@ -46,6 +50,8 @@ impl Vm1Wrapper {
             0,
             "counter_get",
             &EMPTY_RUNTIME_ARGS,
+            None,
+            None,
         );
         let _ = host_error.expect("No error 3");
         log!("counter_get_result_after: {:?}", counter_get_result_2);
@@ -56,6 +62,8 @@ impl Vm1Wrapper {
             0,
             "counter_inc",
             &EMPTY_RUNTIME_ARGS,
+            None,
+            None,
         );
         log!("inc_result {:?}", inc_result_2);
         assert_eq!(inc_result_2, Some(CL_VALUE_UNIT_BYTES.to_vec()));
@@ -66,6 +74,8 @@ impl Vm1Wrapper {
             0,
             "counter_get",
             &EMPTY_RUNTIME_ARGS,
+            None,
+            None,
         );
         let _ = host_error.expect("No error 3");
         log!("counter_get_result_after: {:?}", counter_get_result_3);

--- a/smart_contracts/vm2/sdk/src/casper.rs
+++ b/smart_contracts/vm2/sdk/src/casper.rs
@@ -148,6 +148,26 @@ pub fn write(key: Keyspace, value: &[u8]) -> Result<(), HostResult> {
     result_from_code(ret)
 }
 
+/// Write to the global state.
+pub fn store_package_under_key(named_key: &str) -> Result<(), HostResult> {
+    let input_data = borsh::to_vec(named_key).expect("Expected borsh to work");
+    extern "C" fn alloc_cb(_len: usize, _ctx: *mut c_void) -> *mut u8 {
+        // Write shouldn't have any output data and should not return anything
+        ptr::null_mut()
+    }
+    let ctx = &None::<u8> as *const _ as *mut _;
+    let ret = unsafe {
+        casper_contract_sdk_sys::casper_ffi(
+            GlobalStateFunctionOption::StorePackageUnderKey.into(),
+            input_data.as_ptr(),
+            input_data.len(),
+            alloc_cb,
+            ctx,
+        )
+    };
+    result_from_code(ret)
+}
+
 /// Remove from the global state.
 pub fn remove(key: Keyspace) -> Result<(), HostResult> {
     let input_data = key.to_host_input_data().expect("Expected borsh to work");
@@ -251,9 +271,18 @@ pub fn casper_call(
     transferred_value: u64,
     entry_point: &str,
     input_data: &[u8],
+    contract_version: Option<u32>,
+    contract_protocol_version_major: Option<u32>,
 ) -> (Option<Vec<u8>>, Result<(), CallError>) {
-    let input_data =
-        borsh::to_vec(&(address, input_data, entry_point, transferred_value)).expect("borsh");
+    let input_data = borsh::to_vec(&(
+        address,
+        input_data,
+        entry_point,
+        transferred_value,
+        contract_version,
+        contract_protocol_version_major,
+    ))
+    .expect("borsh");
     let (output_data, result_code) = casper_ffi(ControlFunctionOption::Call.into(), &input_data);
     (output_data, call_result_from_code(result_code))
 }
@@ -343,6 +372,8 @@ pub fn call<T: ToCallData>(
     contract_address: &Address,
     transferred_value: u64,
     call_data: T,
+    contract_version: Option<u32>,
+    contract_protocol_version_major: Option<u32>,
 ) -> Result<CallResult<T>, CallError> {
     let input_data = call_data.input_data().unwrap_or_default();
 
@@ -351,6 +382,8 @@ pub fn call<T: ToCallData>(
         transferred_value,
         call_data.entry_point(),
         &input_data,
+        contract_version,
+        contract_protocol_version_major,
     );
     match result_code {
         Ok(()) | Err(CallError::CalleeRolledBack) => Ok(CallResult::<T> {

--- a/smart_contracts/vm2/sdk/src/casper/native.rs
+++ b/smart_contracts/vm2/sdk/src/casper/native.rs
@@ -745,11 +745,11 @@ mod tests {
             env.add_expectation(ExpectedCall::expect_print("Hello"));
             let _ = casper::print("Hello");
 
-            let key = Keyspace::NamedKey("abc");
+            let key = Keyspace::NamedValue("abc");
             env.add_expectation(ExpectedCall::expect_write(Some((&key, b"value 1"))));
             casper::write(key, b"value 1").unwrap();
 
-            let key = Keyspace::NamedKey("abc");
+            let key = Keyspace::NamedValue("abc");
             env.add_expectation(ExpectedCall::expect_write_with_result_code(
                 Some((&key, b"value 1")),
                 HOST_ERROR_INVALID_INPUT,
@@ -759,7 +759,7 @@ mod tests {
                 Err(HostResult::InvalidInput)
             );
 
-            let key_3 = Keyspace::NamedKey("abc");
+            let key_3 = Keyspace::NamedValue("abc");
             env.add_expectation(ExpectedCall::expect_read(
                 Some(&key_3),
                 Some(b"value 2"),
@@ -767,7 +767,7 @@ mod tests {
             ));
             assert_eq!(casper::read_into_vec(key_3), Ok(Some(b"value 2".to_vec())));
 
-            let key_4 = Keyspace::NamedKey("abc2");
+            let key_4 = Keyspace::NamedValue("abc2");
             env.add_expectation(ExpectedCall::expect_read(
                 Some(&key_4),
                 Some(&[5]),
@@ -775,7 +775,7 @@ mod tests {
             ));
             assert_eq!(casper::read_into_vec(key_4), Ok(Some(vec![5])));
 
-            let key_5 = Keyspace::NamedKey("abc3");
+            let key_5 = Keyspace::NamedValue("abc3");
             env.add_expectation(ExpectedCall::expect_read(
                 Some(&key_5),
                 None,

--- a/smart_contracts/vm2/sdk/src/compat/types.rs
+++ b/smart_contracts/vm2/sdk/src/compat/types.rs
@@ -1,8 +1,10 @@
 mod cl_type;
 mod cl_value;
+mod key;
 mod runtime_args;
 
 pub use bnum::types::U512;
 pub use cl_type::{CLType, CLTyped};
 pub use cl_value::CLValue;
+pub use key::Key;
 pub use runtime_args::{NamedArg, RuntimeArgs};

--- a/smart_contracts/vm2/sdk/src/compat/types/key.rs
+++ b/smart_contracts/vm2/sdk/src/compat/types/key.rs
@@ -1,0 +1,97 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, BorshDeserialize, BorshSerialize)]
+#[borsh(use_discriminant = true)]
+#[repr(u8)]
+pub enum KeyTag {
+    Hash = 1,
+    Package = 16,
+}
+
+/// Subset of node keys that can be stored through the sdk API
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
+pub enum Key {
+    Hash([u8; 32]),
+    Package([u8; 32]),
+}
+
+impl Key {
+    fn get_tag(&self) -> KeyTag {
+        match self {
+            Key::Hash(_) => KeyTag::Hash,
+            Key::Package(_) => KeyTag::Package,
+        }
+    }
+}
+
+impl BorshSerialize for Key {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        let tag_bytes = self.get_tag() as u8;
+        let _ = writer.write(&[tag_bytes])?;
+        let _ = match self {
+            Key::Hash(hash_addr) => writer.write(hash_addr)?,
+            Key::Package(package_addr) => writer.write(package_addr)?,
+        };
+        Ok(())
+    }
+}
+
+impl BorshDeserialize for Key {
+    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let tag = <KeyTag as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
+        let key = match tag {
+            KeyTag::Hash => {
+                let addr = <[u8; 32] as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
+                Key::Hash(addr)
+            }
+            KeyTag::Package => {
+                let addr = <[u8; 32] as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
+                Key::Package(addr)
+            }
+        };
+        Ok(key)
+    }
+}
+
+#[test]
+pub fn test_key_tag_serialization() {
+    assert_eq!(borsh::to_vec(&KeyTag::Hash).unwrap(), [1]);
+    assert_eq!(borsh::to_vec(&KeyTag::Package).unwrap(), [16]);
+    assert_eq!(borsh::from_slice::<KeyTag>(&[1]).unwrap(), KeyTag::Hash);
+    assert_eq!(borsh::from_slice::<KeyTag>(&[16]).unwrap(), KeyTag::Package);
+    assert!(borsh::from_slice::<KeyTag>(&[3]).is_err());
+}
+
+#[test]
+pub fn test_key_serialization() {
+    assert_eq!(
+        borsh::to_vec(&Key::Hash([1; 32])).unwrap(),
+        [
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1
+        ]
+    );
+    assert_eq!(
+        borsh::to_vec(&Key::Package([2; 32])).unwrap(),
+        [
+            16, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+            2, 2, 2, 2
+        ]
+    );
+    let hash_bytes = [
+        1_u8, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        7, 7, 7, 7,
+    ];
+    assert_eq!(
+        borsh::from_slice::<Key>(&hash_bytes).unwrap(),
+        Key::Hash([7; 32])
+    );
+    let package_bytes = [
+        16, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        7, 7, 7,
+    ];
+    assert_eq!(
+        borsh::from_slice::<Key>(&package_bytes).unwrap(),
+        Key::Package([7; 32])
+    );
+}

--- a/smart_contracts/vm2/sdk/src/lib.rs
+++ b/smart_contracts/vm2/sdk/src/lib.rs
@@ -261,6 +261,8 @@ impl<T: ContractRef> CallBuilder<T> {
             &self.address,
             self.transferred_value.unwrap_or(0),
             call_data,
+            None,
+            None,
         )
     }
 
@@ -277,6 +279,8 @@ impl<T: ContractRef> CallBuilder<T> {
             &self.address,
             self.transferred_value.unwrap_or(0),
             call_data,
+            None,
+            None,
         )?;
         call_result.into_result()
     }

--- a/smart_contracts/vm2/sdk/src/types.rs
+++ b/smart_contracts/vm2/sdk/src/types.rs
@@ -161,11 +161,11 @@ impl<T: BorshSerialize + BorshDeserialize> NamedKey<T> {
 
     pub fn write(&self, value: T) {
         let bytes = borsh::to_vec(&value).unwrap();
-        casper::write(Keyspace::NamedKey(self.name), &bytes).unwrap();
+        casper::write(Keyspace::NamedValue(self.name), &bytes).unwrap();
     }
 
     pub fn read(&self) -> Option<T> {
-        let bytes = casper::read_into_vec(Keyspace::NamedKey(self.name)).ok()??;
+        let bytes = casper::read_into_vec(Keyspace::NamedValue(self.name)).ok()??;
         Some(borsh::from_slice(&bytes).unwrap())
     }
 }
@@ -354,6 +354,7 @@ pub enum GlobalStateFunctionOption {
     GetBalance = 403,
     GetInfo = 404,
     Create = 405,
+    StorePackageUnderKey = 406,
 }
 
 impl From<GlobalStateFunctionOption> for u32 {
@@ -378,6 +379,8 @@ impl TryFrom<u32> for GlobalStateFunctionOption {
             Ok(GlobalStateFunctionOption::GetInfo)
         } else if value == 405 {
             Ok(GlobalStateFunctionOption::Create)
+        } else if value == 406 {
+            Ok(GlobalStateFunctionOption::StorePackageUnderKey)
         } else {
             Err(())
         }

--- a/types/src/chainspec/transaction_config/transaction_v1_config.rs
+++ b/types/src/chainspec/transaction_config/transaction_v1_config.rs
@@ -37,15 +37,15 @@ const TRANSACTION_COUNT_INDEX: usize = 4;
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 pub struct TransactionLaneDefinition {
     /// The lane identifier
-    pub id: u8,
+    id: u8,
     /// The maximum length of a transaction in bytes
-    pub max_transaction_length: u64,
+    max_transaction_length: u64,
     /// The max args length size in bytes
-    pub max_transaction_args_length: u64,
+    max_transaction_args_length: u64,
     /// The maximum gas limit
-    pub max_transaction_gas_limit: u64,
+    max_transaction_gas_limit: u64,
     /// The maximum number of transactions
-    pub max_transaction_count: u64,
+    max_transaction_count: u64,
 }
 
 impl TryFrom<Vec<u64>> for TransactionLaneDefinition {
@@ -116,6 +116,21 @@ impl TransactionLaneDefinition {
     /// Returns id
     pub fn id(&self) -> u8 {
         self.id
+    }
+
+    #[cfg(any(feature = "testing", test))]
+    pub fn set_max_transaction_count(&mut self, max_transaction_count: u64) {
+        self.max_transaction_count = max_transaction_count;
+    }
+
+    #[cfg(any(feature = "testing", test))]
+    pub fn set_max_transaction_gas_limit(&mut self, max_transaction_gas_limit: u64) {
+        self.max_transaction_gas_limit = max_transaction_gas_limit;
+    }
+
+    #[cfg(any(feature = "testing", test))]
+    pub fn set_max_transaction_length(&mut self, max_transaction_length: u64) {
+        self.max_transaction_length = max_transaction_length;
     }
 }
 
@@ -514,6 +529,24 @@ impl TransactionV1Config {
                     .cmp(&b.max_transaction_gas_limit)
             })
             .cloned()
+    }
+
+    #[cfg(any(feature = "testing", test))]
+    pub fn very_big_wasm_lane() -> Self {
+        let mut default = Self::default();
+        // Using `set_wasm_lanes` to make sure caches are refreshed
+        default.set_wasm_lanes(
+            // The division here is to avoid overflowing when
+            // adding capacity of lanes
+            vec![TransactionLaneDefinition::new(
+                15,
+                u64::MAX / 5,
+                u64::MAX / 5,
+                u64::MAX / 5,
+                100,
+            )],
+        );
+        default
     }
 }
 

--- a/types/src/transaction/deploy.rs
+++ b/types/src/transaction/deploy.rs
@@ -426,7 +426,7 @@ impl Deploy {
             .get_lane_by_id(lane_id)
             .ok_or(InvalidDeploy::NoLaneMatch)?;
 
-        self.is_valid_size(lane_definition.max_transaction_length as u32)?;
+        self.is_valid_size(lane_definition.max_transaction_length() as u32)?;
 
         let header = self.header();
         let chain_name = &chainspec.network_config.name;
@@ -486,11 +486,11 @@ impl Deploy {
                 got: Box::new(gas_limit.value()),
             });
         }
-        let lane_limit = lane_definition.max_transaction_gas_limit;
+        let lane_limit = lane_definition.max_transaction_gas_limit();
         let lane_limit_as_gas = Gas::new(lane_limit);
         if gas_limit > lane_limit_as_gas {
             debug!(
-                calculated_lane = lane_definition.id,
+                calculated_lane = lane_definition.id(),
                 payment_amount = %gas_limit,
                 %block_gas_limit,
                     "transaction gas limit exceeds lane limit"
@@ -1529,7 +1529,7 @@ impl GasLimited for Deploy {
                 let lane_definition = v1_config
                     .get_lane_by_id(lane_id)
                     .ok_or(InvalidDeploy::NoLaneMatch)?;
-                let computation_limit = lane_definition.max_transaction_gas_limit;
+                let computation_limit = lane_definition.max_transaction_gas_limit();
                 Gas::new(computation_limit)
             } // legacy deploys do not support prepaid
         };
@@ -2290,7 +2290,7 @@ mod tests {
             .transaction_v1_config
             .get_max_wasm_lane_by_gas_limit()
             .unwrap();
-        let amount = U512::from(max_lane.max_transaction_gas_limit + 1);
+        let amount = U512::from(max_lane.max_transaction_gas_limit() + 1);
 
         let payment = ExecutableDeployItem::ModuleBytes {
             module_bytes: Bytes::new(),
@@ -2351,7 +2351,7 @@ mod tests {
             .transaction_v1_config
             .get_max_wasm_lane_by_gas_limit()
             .unwrap();
-        let amount = U512::from(max_lane.max_transaction_gas_limit);
+        let amount = U512::from(max_lane.max_transaction_gas_limit());
 
         let payment = ExecutableDeployItem::ModuleBytes {
             module_bytes: Bytes::new(),

--- a/types/src/transaction/transaction_v1/errors_v1.rs
+++ b/types/src/transaction/transaction_v1/errors_v1.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use super::TransactionV1;
 use crate::{
     addressable_entity::ContractRuntimeTag, bytesrepr, crypto, CLType, DisplayIter, PricingMode,
-    TimeDiff, Timestamp, TransactionEntryPoint, TransactionInvocationTarget, U512,
+    TimeDiff, Timestamp, TransactionEntryPoint, U512,
 };
 
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -275,13 +275,6 @@ pub enum InvalidTransaction {
         /// The attempted amount.
         attempted: U512,
     },
-    /// The transaction invocation target is unsupported under V2 runtime.
-    ///
-    /// This error is returned when the transaction invocation target is not supported by the
-    /// current runtime version.
-    UnsupportedInvocationTarget {
-        id: Option<TransactionInvocationTarget>,
-    },
 }
 
 impl Display for InvalidTransaction {
@@ -512,19 +505,6 @@ impl Display for InvalidTransaction {
                                 formatter,
                                 "the value provided for the delegation amount ({attempted}) cannot be higher than {ceiling}.",
                                 )}
-            InvalidTransaction::UnsupportedInvocationTarget { id: Some(target) } => {
-                        write!(
-                            formatter,
-                            "the transaction invocation target is unsupported under V2 runtime: {target:?}",
-                        )
-                    }
-            InvalidTransaction::UnsupportedInvocationTarget { id :None} => {
-                        write!(
-                            formatter,
-                            "the transaction invocation target is unsupported under V2 runtime",
-                        )
-                    }
-
                     _ => {
                         // This may involve deprecated variants, so we can't list them
                                                 write!(formatter, "deprecated")
@@ -591,8 +571,7 @@ impl StdError for InvalidTransaction {
             | InvalidTransaction::InvalidMinimumDelegationAmount { .. }
             | InvalidTransaction::InvalidMaximumDelegationAmount { .. }
             | InvalidTransaction::InvalidReservedSlots { .. }
-            | InvalidTransaction::InvalidDelegationAmount { .. }
-            | InvalidTransaction::UnsupportedInvocationTarget { .. } => None,
+            | InvalidTransaction::InvalidDelegationAmount { .. } => None,
             #[allow(deprecated)]
             InvalidTransaction::MissingSeed => None,
         }


### PR DESCRIPTION
- Removed the limitation of TransactionV1 with targeting VM2 which prevented using ByPackageHash and ByPackagename transaction invocation targets.
- Changed TransactionLaneDefinition structure to not expose it's fields as public since manipulating them directly didn't cause the caches to invalidate. This made some tests unstable. Instead the structure has getters and setters.